### PR TITLE
Fix for Jungle Wyvern only dropping souls on second kill

### DIFF
--- a/NPCs/Bosses/JungleWyvern/JungleWyvernHead.cs
+++ b/NPCs/Bosses/JungleWyvern/JungleWyvernHead.cs
@@ -245,11 +245,9 @@ namespace tsorcRevamp.NPCs.Bosses.JungleWyvern {
 			Item.NewItem(npc.getRect(), ItemID.NecroHelmet);
 			Item.NewItem(npc.getRect(), ItemID.NecroBreastplate);
 			Item.NewItem(npc.getRect(), ItemID.NecroGreaves);
-			if (tsorcRevampWorld.Slain.ContainsKey(ModContent.NPCType<JungleWyvernHead>())) { //if the boss has been killed
-				if (tsorcRevampWorld.Slain[ModContent.NPCType<JungleWyvernHead>()] == 0) { //and the key value is 0
-					Item.NewItem(npc.getRect(), ModContent.ItemType<DarkSoul>(), 9000);
-					tsorcRevampWorld.Slain[ModContent.NPCType<JungleWyvernHead>()] = 1; //set the value to 1
-				}
+			if (!(tsorcRevampWorld.Slain.ContainsKey(ModContent.NPCType<JungleWyvernHead>())))
+			{ //If the boss has not yet been killed
+				Item.NewItem(npc.getRect(), ModContent.ItemType<DarkSoul>(), 9000); //Then drop the souls
 			}
 		}
     }


### PR DESCRIPTION
Fixes the extremely cursed "It only drops souls on the second kill" behavior of the Jungle Wyvern. The key doesn't exist until a boss has already been killed, so instead of checking if the key is 1 this code just checks if the key exists at all.