### PR TITLE
EoW Soul Drop Fix

### DIFF
--- a/NPCs/GlobalNPC.cs
+++ b/NPCs/GlobalNPC.cs
@@ -121,6 +121,29 @@ namespace tsorcRevamp.NPCs {
                     }
                 }
                 #endregion
+
+                #region EoW drops souls in a unique way
+                if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)))
+                {
+
+                    DarkSoulQuantity = 110;
+
+                    if (Main.expertMode)
+                    {
+                        //EoW has 5 more segments in Expert mode, so its drops per segment is reduced slightly to keep it consistent. 
+                        DarkSoulQuantity = 102;
+                    }
+                    if (NPC.downedBoss2)
+                    {
+                        //EoW still drops this many souls per segment even after the first kill. The difference between normal and expert is small enough it would get rounded away at this point.
+                        DarkSoulQuantity = 10;
+                    }
+
+                    Item.NewItem(npc.getRect(), mod.ItemType("DarkSoul"), DarkSoulQuantity);
+                    DarkSoulQuantity = 0;
+                }
+                #endregion
+
                 if (DarkSoulQuantity > 0) {
                     Item.NewItem(npc.getRect(), ModContent.ItemType<DarkSoul>(), DarkSoulQuantity);
                 }

--- a/NPCs/VanillaChanges.cs
+++ b/NPCs/VanillaChanges.cs
@@ -1822,12 +1822,12 @@ namespace tsorcRevamp.NPCs {
                 Item.NewItem(npc.getRect(), mod.ItemType("BloodredMossClump"));
             }
 
-             if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)) && !Main.expertMode) {
+            if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)) && !Main.expertMode) {
                  
                 Item.NewItem(npc.getRect(), ItemID.DemoniteOre, 4);
                 Item.NewItem(npc.getRect(), ItemID.ShadowScale, 4);
             }
-            
+
             if ((npc.type >= NPCID.BigHornetStingy && npc.type <= NPCID.LittleHornetFatty) ||
                                 (npc.type >= NPCID.GiantMossHornet && npc.type <= NPCID.LittleStinger) ||
                                 npc.type == NPCID.Hornet || npc.type == NPCID.ManEater ||

--- a/NPCs/VanillaChanges.cs
+++ b/NPCs/VanillaChanges.cs
@@ -1822,6 +1822,12 @@ namespace tsorcRevamp.NPCs {
                 Item.NewItem(npc.getRect(), mod.ItemType("BloodredMossClump"));
             }
 
+             if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)) && !Main.expertMode) {
+                 
+                Item.NewItem(npc.getRect(), ItemID.DemoniteOre, 4);
+                Item.NewItem(npc.getRect(), ItemID.ShadowScale, 4);
+            }
+            
             if ((npc.type >= NPCID.BigHornetStingy && npc.type <= NPCID.LittleHornetFatty) ||
                                 (npc.type >= NPCID.GiantMossHornet && npc.type <= NPCID.LittleStinger) ||
                                 npc.type == NPCID.Hornet || npc.type == NPCID.ManEater ||
@@ -1832,11 +1838,7 @@ namespace tsorcRevamp.NPCs {
                 }
             }
             
-             if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)) && !Main.expertMode) {
-                 
-                Item.NewItem(npc.getRect(), ItemID.DemoniteOre, 4);
-                Item.NewItem(npc.getRect(), ItemID.ShadowScale, 4);
-            }
+            
 
             if (npc.type == NPCID.KingSlime) {
                 Item.NewItem(npc.getRect(), mod.ItemType("DarkSoul"), 500);

--- a/NPCs/VanillaChanges.cs
+++ b/NPCs/VanillaChanges.cs
@@ -1822,12 +1822,6 @@ namespace tsorcRevamp.NPCs {
                 Item.NewItem(npc.getRect(), mod.ItemType("BloodredMossClump"));
             }
 
-            if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)) && !Main.expertMode) {
-                Item.NewItem(npc.getRect(), mod.ItemType("DarkSoul"), 10);
-                Item.NewItem(npc.getRect(), ItemID.DemoniteOre, 4);
-                Item.NewItem(npc.getRect(), ItemID.ShadowScale, 4);
-            }
-
             if ((npc.type >= NPCID.BigHornetStingy && npc.type <= NPCID.LittleHornetFatty) ||
                                 (npc.type >= NPCID.GiantMossHornet && npc.type <= NPCID.LittleStinger) ||
                                 npc.type == NPCID.Hornet || npc.type == NPCID.ManEater ||

--- a/NPCs/VanillaChanges.cs
+++ b/NPCs/VanillaChanges.cs
@@ -1831,6 +1831,12 @@ namespace tsorcRevamp.NPCs {
                     Item.NewItem(npc.getRect(), mod.ItemType("BloodredMossClump"));
                 }
             }
+            
+             if (((npc.type == NPCID.EaterofWorldsHead) || (npc.type == NPCID.EaterofWorldsBody) || (npc.type == NPCID.EaterofWorldsTail)) && !Main.expertMode) {
+                 
+                Item.NewItem(npc.getRect(), ItemID.DemoniteOre, 4);
+                Item.NewItem(npc.getRect(), ItemID.ShadowScale, 4);
+            }
 
             if (npc.type == NPCID.KingSlime) {
                 Item.NewItem(npc.getRect(), mod.ItemType("DarkSoul"), 500);


### PR DESCRIPTION
Changes how the Eater of Worlds drops its souls to make it follow intended behavior.