### PR TITLE
Disable usage of held item while hovering in potion bag

### DIFF
--- a/UI/PotionBagUIState.cs
+++ b/UI/PotionBagUIState.cs
@@ -33,7 +33,16 @@ namespace tsorcRevamp.UI
             PotionBagUI.Width.Set(400, 0f);
             PotionBagUI.Height.Set(255, 0f);
             PotionBagUI.BackgroundColor = new Color(30, 29, 43);
-
+            
+            PotionBagUI.OnUpdate += (UIElement affectedElement) => 
+            {
+                //Don't use the player's held item if the mouse is hovering over this.
+                if (affectedElement.ContainsPoint(Main.MouseScreen))
+                {
+                    Main.LocalPlayer.mouseInterface = true;
+                }
+            };
+            
             int slotIndex = 0;
             for (int i = 0; i < 5; i++)
             {


### PR DESCRIPTION
### The Issue
As it is now, hovering your mouse between the slots in the potion bag will use the item you're holding. This is bad, because the potion bag is specifically designed for holding potions, which are consumable! A simple misclick or even just a poorly-timed shake of the mouse can cause a player to waste a potentially valuable potion.

### What This Does
This updates PotionBagUIState.cs and adds a new function to the potion bag's UIPanel's Update procedure. Now, on Update, it checks if the mouse position is covered by the UIPanel, and if it is, it disables using the held items. This does not affect placing items in the slots (I triple-checked!). 

Here's a video of it in action: https://youtu.be/KH7F1_vztMI