### PR TITLE
Remove signs from the breakable items list

### DIFF
--- a/tsorcRevamp.cs
+++ b/tsorcRevamp.cs
@@ -194,7 +194,7 @@ namespace tsorcRevamp
                 51, //cobweb
                 52, //vines
                 53, //sand
-                55, //Sign 
+                //55, //Sign (Removed - signs shouldn't be breakable.) 
                 //56, //obsidian (removed at tim's request)
                 60, //jungle grass
                 61, //small jungle plants


### PR DESCRIPTION
Signs being breakable has been marked as a bug in the Discord. This fixes that.

This could also be put to rest by moving the unbreakable check on line 1658 above the KillAllowed check on line 1646, so the unbreakable list will take precedence... but I figured that's a design question best left to the people actually overseeing this mod.

Tested in VS, confirmed works.