### PR TITLE
Remove gravitation potion screen flipping again

### DIFF
--- a/ILEdits.cs
+++ b/ILEdits.cs
@@ -30,10 +30,10 @@ namespace tsorcRevamp
                 IL.Terraria.Main.DoDraw += GravPatch_Rasterizer;
 
                 //text & health bars
-                //TODO: minion tag indicator
                 IL.Terraria.CombatText.NewText_Rectangle_Color_string_bool_bool += GravPatch_ReplaceOne;
                 IL.Terraria.Main.DrawHealthBar += GravPatch_ReplaceOne;
                 IL.Terraria.Main.DrawItemTextPopups += GravPatch_ReplaceOne;
+                IL.Terraria.Main.DrawInterface_1_2_DrawEntityMarkersInWorld += GravPatch_ReplaceOne;
 
                 //Emote bubbles, chat bubbles that appear when hovering over NPCs,
                 //NPC house indicators, mouse over text

--- a/ILEdits.cs
+++ b/ILEdits.cs
@@ -22,95 +22,58 @@ namespace tsorcRevamp
             //editing a get accessor of a property and built in hooks don't have any of those
             HookEndpointManager.Modify(typeof(Terraria.GameContent.UI.WiresUI.Settings).GetProperty("DrawWires").GetGetMethod(), new ILContext.Manipulator(DrawWires_Patch));
 
-            IL.Terraria.Main.DoDraw += GravPatch_ReplaceAll;
 
-            IL.Terraria.CombatText.NewText_Rectangle_Color_string_bool_bool += GravPatch_ReplaceOne;
-            IL.Terraria.Main.DrawHealthBar += GravPatch_ReplaceOne;
-            IL.Terraria.Main.DrawItemTextPopups += GravPatch_ReplaceOne;
-
-            IL.Terraria.Main.DrawNPCChatBubble += GravPatch_ReplaceOne;
-            IL.Terraria.GameContent.UI.EmoteBubble.Draw += GravPatch_ReplaceOne;
-            IL.Terraria.Main.DrawMouseOver += GravPatch_ReplaceOne;
-            IL.Terraria.Main.DrawNPCHousesInWorld += GravPatch_ReplaceOne;
-
-            IL.Terraria.GameInput.SmartSelectGamepadPointer.SmartSelectLookup_GetTargetTile += GravPatch_ReplaceAll;
-
-            IL.Terraria.Graphics.Capture.CaptureInterface.ModeEdgeSelection.DrawCursors += GravPatch_ReplaceOne;
-            IL.Terraria.Graphics.Capture.CaptureInterface.ModeDragBounds.DragBounds += GravPatch_ReplaceOne;
-            IL.Terraria.Graphics.Effects.FilterManager.EndCapture += GravPatch_ReplaceAll;
-
-            HookEndpointManager.Modify(typeof(Main).GetProperty("MouseWorld").GetGetMethod(), new ILContext.Manipulator(GravPatch_ReplaceOne));
-
-            IL.Terraria.Player.ItemCheck_UseRodOfDiscord += GravPatch_ReplaceOne;
-            IL.Terraria.Player.ItemCheck_Shoot += GravPatch_ReplaceAll;
-
-            //don't know what this does?
-            //            IL.Terraria.DataStructures.EntityShadowInfo.CopyPlayer += GravPatch_ReplaceOne;
-
-            //tests
-            //todo: smart cursor
-
-            /*
             if (ModContent.GetInstance<tsorcRevampConfig>().GravityFix)
             {
-                IL.Terraria.Main.DoDraw += Gravity_Screenflip_Patch;
-                IL.Terraria.Main.DoDraw += Gravity_Rasterizer_Patch;
-                IL.Terraria.Main.DoDraw += Gravity_CombatText_Patch;
-                IL.Terraria.Main.DrawInterface_14_EntityHealthBars += Gravity_Generic_Patch;
-                IL.Terraria.Main.DrawInterface_19_SignTileBubble += Gravity_Generic_Patch;
-                IL.Terraria.Player.QuickGrapple += Gravity_Generic_Patch;
-                
-                IL.Terraria.Player.Update += Gravity_TileAim_Patch;
-                IL.Terraria.Player.ItemCheck += Gravity_Aim_Patch; //done?
+                //main screen flip
+                IL.Terraria.Main.DoDraw += GravPatch_ReplaceAll;
+                IL.Terraria.Main.DoDraw += GravPatch_Rasterizer;
 
-            }*/
+                //text & health bars
+                //TODO: minion tag indicator
+                IL.Terraria.CombatText.NewText_Rectangle_Color_string_bool_bool += GravPatch_ReplaceOne;
+                IL.Terraria.Main.DrawHealthBar += GravPatch_ReplaceOne;
+                IL.Terraria.Main.DrawItemTextPopups += GravPatch_ReplaceOne;
+
+                //Emote bubbles, chat bubbles that appear when hovering over NPCs,
+                //NPC house indicators, mouse over text
+                IL.Terraria.Main.DrawNPCChatBubble += GravPatch_ReplaceOne;
+                IL.Terraria.GameContent.UI.EmoteBubble.Draw += GravPatch_ReplaceOne;
+                IL.Terraria.Main.DrawMouseOver += GravPatch_ReplaceOne;
+                IL.Terraria.Main.DrawNPCHousesInWorld += GravPatch_ReplaceOne;
+
+                IL.Terraria.GameInput.SmartSelectGamepadPointer.SmartSelectLookup_GetTargetTile += GravPatch_ReplaceAll;
+
+                //Screencap mode stuff
+                //TODO: snapshot boundaries still borked
+                IL.Terraria.Graphics.Capture.CaptureInterface.ModeEdgeSelection.DrawCursors += GravPatch_ReplaceOne;
+                IL.Terraria.Graphics.Capture.CaptureInterface.ModeDragBounds.DragBounds += GravPatch_ReplaceOne;
+                IL.Terraria.Graphics.Effects.FilterManager.EndCapture += GravPatch_ReplaceAll;
+
+                //MouseWorld property
+                HookEndpointManager.Modify(typeof(Main).GetProperty("MouseWorld").GetGetMethod(), new ILContext.Manipulator(GravPatch_ReplaceOne));
+
+                //Aiming
+                //TODO: portal gun (needed?)
+                IL.Terraria.Player.ItemCheck_UseRodOfDiscord += GravPatch_ReplaceOne;
+                IL.Terraria.Player.ItemCheck_Shoot += GravPatch_ReplaceAll;
+                IL.Terraria.Player.Update += GravPatch_TileAim;
+
+                //Smart cursor
+                IL.Terraria.Main.DrawSmartCursor += GravPatch_ReplaceOne;
+                IL.Terraria.Main.DrawSmartInteract += GravPatch_ReplaceOne;
+
+                //grappling
+                IL.Terraria.Player.QuickGrapple += GravPatch_ReplaceOne;
+            }
 
             //IL.Terraria.Main.DrawPlayer_DrawAllLayers += Rotate_Patch;
 
         }
 
-
-
         internal static void UnloadILs()
         {
 
-        }
-
-        //Goes right after the current gravDir is loaded onto the stack. Eats that value, then places "1" on the stack. Useful to make code run as if the gravDir is 1.
-        internal static float GravPatch_Delegate(float oldValue)
-        {
-            return 1;
-        }
-
-        internal static void GravPatch_ReplaceAll(ILContext il)
-        {
-            ILCursor c = new ILCursor(il);
-            //TODO remove debug stuff b4 PR
-#if DEBUG
-            int gravsFound = 0;
-#endif
-            while (c.TryGotoNext(instr => instr.MatchLdfld<Player>("gravDir")))
-            {
-#if DEBUG
-                gravsFound++;
-                ModContent.GetInstance<tsorcRevamp>().Logger.Debug("GRAVDIR: " + gravsFound);
-#endif
-                c.Index++;
-                c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
-            }
-
-        }
-
-        //Can be used to patch any function where gravDir is used only once.
-        internal static void GravPatch_ReplaceOne(ILContext il)
-        {
-            ILCursor c = new ILCursor(il);
-            if (!c.TryGotoNext(instr => instr.MatchLdfld<Player>("gravDir")))
-            {
-                throw new Exception("Could not find instruction to patch (GravPatch_ReplaceOne)");
-            }
-            c.Index += 1;
-            c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
         }
 
         internal static void DrawWires_Patch(ILContext il)
@@ -174,30 +137,24 @@ namespace tsorcRevamp
         }
 
 
-        //This takes an int to ensure that it eats the old value and removes it from the stack, letting us push 0 (no screenflip) to it instead
-        internal static int Gravity_Screenflip_Delegate(int oldValue)
+        //Goes right after the current gravDir is loaded onto the stack. Eats that value, then places "1" on the stack. Useful to make code run as if the gravDir is 1.
+        internal static float GravPatch_Delegate(float oldValue)
         {
-            return 0;
+            return 1;
         }
 
-        internal static void Gravity_Rasterizer_Patch(ILContext il)
+        internal static void GravPatch_ReplaceAll(ILContext il)
         {
             ILCursor c = new ILCursor(il);
-            if (!c.TryGotoNext(instr => instr.MatchLdsfld<Microsoft.Xna.Framework.Graphics.RasterizerState>("CullClockwise")))
+            while (c.TryGotoNext(instr => instr.MatchLdfld<Player>("gravDir")))
             {
-                throw new Exception("Could not find instruction to patch (Gravity_Rasterizer_Patch)");
+                c.Index++;
+                c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
             }
-            c.Index++;
-            c.EmitDelegate<Func<Microsoft.Xna.Framework.Graphics.RasterizerState, Microsoft.Xna.Framework.Graphics.RasterizerState>>(Gravity_Rasterizer_Delegate);
+
         }
 
-        //Again, this exists to eat the old state and push the desired one
-        internal static Microsoft.Xna.Framework.Graphics.RasterizerState Gravity_Rasterizer_Delegate(Microsoft.Xna.Framework.Graphics.RasterizerState oldState)
-        {
-            return Microsoft.Xna.Framework.Graphics.RasterizerState.CullCounterClockwise;
-        }
-
-        internal static void Gravity_TileAim_Patch(ILContext il)
+        internal static void GravPatch_TileAim(ILContext il)
         {
             ILCursor c = new ILCursor(il);
             if (!c.TryGotoNext(instr => instr.MatchLdcR4(16) && instr.Next.MatchDiv() && instr.Next.Next.MatchConvI4() && instr.Next.Next.Next.MatchStsfld<Player>("tileTargetY") && instr.Next.Next.Next.Next.MatchLdarg(0) && instr.Next.Next.Next.Next.Next.MatchLdfld<Player>("gravDir")))
@@ -208,40 +165,35 @@ namespace tsorcRevamp
             c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
         }
 
-        internal static void Gravity_CombatText_Patch(ILContext il)
-        {
-            ILCursor c = new ILCursor(il);
-            if (!c.TryGotoNext(instr => instr.MatchLdfld<Player>("gravDir") && instr.Next.MatchLdcR4(-1) && instr.Next.Next.Next.MatchLdsfld<Main>("combatText") && instr.Next.Next.Next.Next.Next.MatchLdelemRef()))
-            {
-                throw new Exception("Could not find instruction to patch (Gravity_CombatText_Patch)");
-            }
-            c.Index += 1;
-            c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
-        }
-
-        internal static void Gravity_Aim_Patch(ILContext il)
-        {
-            ILCursor c = new ILCursor(il);
-            //There are like 50 sequences just like this in the player file, so this one was annoying to pin down the location of
-            if (!c.TryGotoNext(instr => instr.MatchDup() && instr.Next.MatchLdfld<Microsoft.Xna.Framework.Vector2>("X") && instr.Next.Next.Next.MatchLdfld<Microsoft.Xna.Framework.Vector2>("Y") && instr.Next.Next.Next.Next.Next.MatchLdarg(0) && instr.Next.Next.Next.Next.Next.Next.MatchLdfld<Player>("gravDir") && instr.Next.Next.Next.Next.Next.Next.Next.MatchLdcR4(-1)))
-            {
-                throw new Exception("Could not find instruction to patch (Gravity_Aim_Patch)");
-            }
-            c.Index += 7;
-            c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
-        }
-
         //Can be used to patch any function where gravDir is used only once.
-        internal static void Gravity_Generic_Patch(ILContext il)
+        internal static void GravPatch_ReplaceOne(ILContext il)
         {
             ILCursor c = new ILCursor(il);
             if (!c.TryGotoNext(instr => instr.MatchLdfld<Player>("gravDir")))
             {
-                throw new Exception("Could not find instruction to patch (Gravity_Generic_Patch)");
+                throw new Exception("Could not find instruction to patch (GravPatch_ReplaceOne)");
             }
             c.Index += 1;
             c.EmitDelegate<Func<float, float>>(GravPatch_Delegate);
         }
+
+        internal static void GravPatch_Rasterizer(ILContext il)
+        {
+            ILCursor c = new ILCursor(il);
+            if (!c.TryGotoNext(instr => instr.MatchLdsfld<Microsoft.Xna.Framework.Graphics.RasterizerState>("CullClockwise")))
+            {
+                throw new Exception("Could not find instruction to patch (Gravity_Rasterizer_Patch)");
+            }
+            c.Index++;
+            c.EmitDelegate<Func<Microsoft.Xna.Framework.Graphics.RasterizerState, Microsoft.Xna.Framework.Graphics.RasterizerState>>(GravPatch_Rasterizer_Delegate);
+        }
+
+        //Again, this exists to eat the old state and push the desired one
+        internal static Microsoft.Xna.Framework.Graphics.RasterizerState GravPatch_Rasterizer_Delegate(Microsoft.Xna.Framework.Graphics.RasterizerState oldState)
+        {
+            return Microsoft.Xna.Framework.Graphics.RasterizerState.CullCounterClockwise;
+        }
+
 
         //Stick this into a section of code you are trying to *avoid* running to let you know for sure if it still is (if so you messed up skipping it, if not you edited the wrong section)
         internal static void DebugDelegate()

--- a/tsorcRevampConfig.cs
+++ b/tsorcRevampConfig.cs
@@ -97,7 +97,7 @@ namespace tsorcRevamp
         [SliderColor(224, 165, 56, 128)]
         [ReloadRequired]
         [DefaultValue(true)]
-        [Tooltip("CURRENTLY DISABLED! Needs to be redone completely for 1.4" +
+        [Tooltip("IN BETA! (Mostly working, but there will be some minor bugs)" +
             "\nFlipping gravity will only flip your character instead of the whole screen.")]
         public bool GravityFix { get; set; }
         


### PR DESCRIPTION
"Hey you wanna go get something to eat?"
"No thanks I'm looking at the decompiled Terraria source code"

The gravitation potion screen flipping patch was broken in 1.4. This returns it.