### PR TITLE
Major Vanilla Treasure Bags rework and minor fixes

### DIFF
--- a/Items/VanillaItems/RecipeHelper.cs
+++ b/Items/VanillaItems/RecipeHelper.cs
@@ -176,6 +176,8 @@ namespace tsorcRevamp
             RecipeRemover(ItemID.MechanicalSkull);
             RecipeRemover(ItemID.MechanicalWorm);
 
+            RecipeRemover(ItemID.WormFood);
+
             RecipeIngredientAdder(ItemID.IvyWhip, ItemID.BeeWax, 1);
             RecipeIngredientAdder(ItemID.GrapplingHook, ItemID.BeeWax, 1);
             RecipeIngredientAdder(ItemID.AmethystHook, ItemID.BeeWax, 1);

--- a/NPCs/GlobalNPC.cs
+++ b/NPCs/GlobalNPC.cs
@@ -419,7 +419,7 @@ namespace tsorcRevamp.NPCs
                             }
                         }
 
-                        tsorcRevampWorld.Slain.Add(npc.type, 0);
+                        tsorcRevampWorld.Slain.Add(npc.type, 1);
 
                         if (Main.netMode == NetmodeID.Server)
                         {
@@ -605,44 +605,44 @@ namespace tsorcRevamp.NPCs
 
             return base.PreKill(npc);
         }
-        public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
-        {           
+        // public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot)
+        // {           
 
-            if (ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems)
-            {
+        //     if (ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems)
+        //     {
 
-                List<IItemDropRule> ruleList = npcLoot.Get();
+        //         List<IItemDropRule> ruleList = npcLoot.Get();
 
-                for (int i = 0; i < ruleList.Count; i++)
-                {
-                    if (ruleList[i] is CommonDrop rodRule && rodRule.itemId == ItemID.RodofDiscord)
-                    {
-                        //Hacky
-                        rodRule.chanceNumerator = 0;
-                    }
+        //         for (int i = 0; i < ruleList.Count; i++)
+        //         {
+        //             if (ruleList[i] is CommonDrop rodRule && rodRule.itemId == ItemID.RodofDiscord)
+        //             {
+        //                 //Hacky
+        //                 rodRule.chanceNumerator = 0;
+        //             }
 
 
-                    /* 
-                    if (ruleList[i] is OneFromOptionsDropRule bossRule)
-                    {
-                        for(int j = 0; j < bossRule.dropIds.Length; j++)
-                        {
-                            if (bossRule.dropIds[j] == ItemID.Picksaw)
-                            {
-                                //You have to recreate the rule from scratch. I'm just gonna disable the picksaw in CanUseItem instead.
-                                OneFromOptionsDropRule newRule = new OneFromOptionsDropRule(1, 1, ItemID.Stynger, ItemID.GolemFist, ItemID.GolemMask);
+        //             /* 
+        //             if (ruleList[i] is OneFromOptionsDropRule bossRule)
+        //             {
+        //                 for(int j = 0; j < bossRule.dropIds.Length; j++)
+        //                 {
+        //                     if (bossRule.dropIds[j] == ItemID.Picksaw)
+        //                     {
+        //                         //You have to recreate the rule from scratch. I'm just gonna disable the picksaw in CanUseItem instead.
+        //                         OneFromOptionsDropRule newRule = new OneFromOptionsDropRule(1, 1, ItemID.Stynger, ItemID.GolemFist, ItemID.GolemMask);
 
-                            }
-                            if (bossRule.dropIds[j] == ItemID.SlimeHook)
-                            {
-                                bossRule.RemoveDrop(ItemID.SlimeHook); //No equivalent to this exists. How do you remove an item from a drop list?
-                            }
-                        }
-                        sawRule.chanceNumerator = 0;
-                    }*/
-                }
-            }
-        }
+        //                     }
+        //                     if (bossRule.dropIds[j] == ItemID.SlimeHook)
+        //                     {
+        //                         bossRule.RemoveDrop(ItemID.SlimeHook); //No equivalent to this exists. How do you remove an item from a drop list?
+        //                     }
+        //                 }
+        //                 sawRule.chanceNumerator = 0;
+        //             }*/
+        //         }
+        //     }
+        // }
 
         //TODO
         /*

--- a/NPCs/VanillaChanges.cs
+++ b/NPCs/VanillaChanges.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.GameContent;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.Graphics.Shaders;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -720,9 +721,8 @@ namespace tsorcRevamp.NPCs
 
                 case (NPCID.MeteorHead):
                     {
-                        
-                            npc.defense = 10;
-                            npc.value = 300;
+                        npc.defense = 10;
+                        npc.value = 300;
 
                         if (Main.hardMode)
                         {
@@ -3181,58 +3181,57 @@ namespace tsorcRevamp.NPCs
                     }
                 }
                 
-                if (npc.type == NPCID.BigRainZombie
-                        
-                        || npc.type == NPCID.FemaleZombie
-                        || npc.type == NPCID.BigFemaleZombie
-                        || npc.type == NPCID.SmallFemaleZombie
-                        || npc.type == NPCID.SmallRainZombie
-                        || npc.type == NPCID.ZombieRaincoat
-                        || npc.type == NPCID.UmbrellaSlime
-                        || npc.type == NPCID.BigHeadacheSkeleton
-                        || npc.type == NPCID.SmallHeadacheSkeleton
-                        || npc.type == NPCID.BigSlimedZombie
-                        || npc.type == NPCID.RedSlime
-                        || npc.type == NPCID.BlueSlime
-                        || npc.type == NPCID.GreenSlime
-                        || npc.type == NPCID.TheGroom
-                        || npc.type == NPCID.SantaClaus
-                        || npc.type == NPCID.Unicorn
-                        || npc.type == NPCID.ZombieEskimo
-                        || npc.type == NPCID.PigronCorruption
-                        || npc.type == NPCID.PigronHallow
-                        || npc.type == NPCID.PigronCrimson
-                        || npc.type == NPCID.FaceMonster
-                        || npc.type == NPCID.SlimedZombie
-                        || npc.type == NPCID.HeadacheSkeleton
-                        || npc.type == NPCID.AngryNimbus
-                        || npc.type == NPCID.FloatyGross
-                        || npc.type == NPCID.SkeletonSniper
-                        || npc.type == NPCID.TacticalSkeleton
-                        || npc.type == NPCID.HoppinJack
-                        || npc.type == NPCID.SkeletonTopHat
-                        || npc.type == NPCID.SkeletonAstonaut
-                        || npc.type == NPCID.ZombieSuperman
-                        || npc.type == NPCID.ZombieXmas
-                        || npc.type == NPCID.ZombieSweater
-                        || npc.type == NPCID.SlimeRibbonWhite
-                        || npc.type == NPCID.SlimeRibbonYellow
-                        || npc.type == NPCID.SlimeRibbonGreen
-                        || npc.type == NPCID.SlimeRibbonRed
-                        || npc.type == NPCID.BunnyXmas
-                        || npc.type == NPCID.ArmedZombieEskimo
-                        || npc.type == NPCID.ArmedZombieSlimed
-                        || npc.type == NPCID.BoneThrowingSkeleton2
-                        || npc.type == NPCID.BoneThrowingSkeleton3
-                        || npc.type == NPCID.Butcher
-                        || npc.type == NPCID.TheBride
-                        || npc.type == NPCID.MartianProbe
-                        || npc.type == NPCID.WindyBalloon
-                        || npc.type == NPCID.ToxicSludge
-                        || npc.type == NPCID.BloodCrawlerWall
-                        || npc.type == NPCID.BoundGoblin
-                        || npc.type == NPCID.BoundMechanic
-                        || npc.type == NPCID.BoundWizard)
+                if (   npc.type == NPCID.BigRainZombie
+                    || npc.type == NPCID.FemaleZombie
+                    || npc.type == NPCID.BigFemaleZombie
+                    || npc.type == NPCID.SmallFemaleZombie
+                    || npc.type == NPCID.SmallRainZombie
+                    || npc.type == NPCID.ZombieRaincoat
+                    || npc.type == NPCID.UmbrellaSlime
+                    || npc.type == NPCID.BigHeadacheSkeleton
+                    || npc.type == NPCID.SmallHeadacheSkeleton
+                    || npc.type == NPCID.BigSlimedZombie
+                    || npc.type == NPCID.RedSlime
+                    || npc.type == NPCID.BlueSlime
+                    || npc.type == NPCID.GreenSlime
+                    || npc.type == NPCID.TheGroom
+                    || npc.type == NPCID.SantaClaus
+                    || npc.type == NPCID.Unicorn
+                    || npc.type == NPCID.ZombieEskimo
+                    || npc.type == NPCID.PigronCorruption
+                    || npc.type == NPCID.PigronHallow
+                    || npc.type == NPCID.PigronCrimson
+                    || npc.type == NPCID.FaceMonster
+                    || npc.type == NPCID.SlimedZombie
+                    || npc.type == NPCID.HeadacheSkeleton
+                    || npc.type == NPCID.AngryNimbus
+                    || npc.type == NPCID.FloatyGross
+                    || npc.type == NPCID.SkeletonSniper
+                    || npc.type == NPCID.TacticalSkeleton
+                    || npc.type == NPCID.HoppinJack
+                    || npc.type == NPCID.SkeletonTopHat
+                    || npc.type == NPCID.SkeletonAstonaut
+                    || npc.type == NPCID.ZombieSuperman
+                    || npc.type == NPCID.ZombieXmas
+                    || npc.type == NPCID.ZombieSweater
+                    || npc.type == NPCID.SlimeRibbonWhite
+                    || npc.type == NPCID.SlimeRibbonYellow
+                    || npc.type == NPCID.SlimeRibbonGreen
+                    || npc.type == NPCID.SlimeRibbonRed
+                    || npc.type == NPCID.BunnyXmas
+                    || npc.type == NPCID.ArmedZombieEskimo
+                    || npc.type == NPCID.ArmedZombieSlimed
+                    || npc.type == NPCID.BoneThrowingSkeleton2
+                    || npc.type == NPCID.BoneThrowingSkeleton3
+                    || npc.type == NPCID.Butcher
+                    || npc.type == NPCID.TheBride
+                    || npc.type == NPCID.MartianProbe
+                    || npc.type == NPCID.WindyBalloon
+                    || npc.type == NPCID.ToxicSludge
+                    || npc.type == NPCID.BloodCrawlerWall
+                    || npc.type == NPCID.BoundGoblin
+                    || npc.type == NPCID.BoundMechanic
+                    || npc.type == NPCID.BoundWizard)
                 {
                     npc.active = false;
                 }
@@ -5880,6 +5879,13 @@ namespace tsorcRevamp.NPCs
             if (npc.type == NPCID.LunarTowerStardust) tsorcRevampWorld.DownedStardust = true;
             if (npc.type == NPCID.LunarTowerSolar) tsorcRevampWorld.DownedSolar = true;
             #endregion
+        }
+
+        public override void ModifyNPCLoot(NPC npc, NPCLoot npcLoot) 
+        {
+            if (npc.type == NPCID.CultistBoss) {
+                npcLoot.Add(ItemDropRule.BossBag(ItemID.CultistBossBag));
+            }
         }
 
         public override void ModifyHitByItem(NPC npc, Player player, Item item, ref int damage, ref float knockback, ref bool crit)

--- a/tsorcDropRules.cs
+++ b/tsorcDropRules.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Terraria.ModLoader;
 using Terraria.GameContent.ItemDropRules;
 
 namespace tsorcRevamp {
@@ -55,5 +56,43 @@ namespace tsorcRevamp {
         public bool CanDrop(DropAttemptInfo info) => tsorcRevampWorld.SuperHardMode;
         public bool CanShowItemDropInUI() => true;
         public string GetConditionDescription() => "[c/ff9999:Only drops in Super Hardmode]";
+    }
+
+    public class FirstBagRule : IItemDropRuleCondition, IProvideItemConditionDescription {
+        public virtual bool CanDrop(DropAttemptInfo info) {
+            tsorcRevampPlayer modPlayer = info.player.GetModPlayer<tsorcRevampPlayer>();
+            if (modPlayer.bagsOpened.Contains(info.item)) {
+                return false;
+            }
+            return true;
+        }
+
+        public bool CanShowItemDropInUI() => true;
+
+        public virtual string GetConditionDescription() => "[c/ff9999: Only drops from the first opened specific Bag";
+    }
+
+    public class FirstBagCursedRule : FirstBagRule {
+        public override bool CanDrop(DropAttemptInfo info) {
+            tsorcRevampPlayer modPlayer = info.player.GetModPlayer<tsorcRevampPlayer>();
+            if (modPlayer.BearerOfTheCurse & base.CanDrop(info)) {
+                return true;
+            }
+            return false;
+        }
+
+        public override string GetConditionDescription() => "[c/ff9999: Only drops from the first opened specific Bag while the player is a Bearer of the Curse";
+    }
+
+    public class AdventureModeRule : IItemDropRuleCondition, IProvideItemConditionDescription {
+        public bool CanDrop(DropAttemptInfo info) => ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems;
+        public bool CanShowItemDropInUI() => true;
+        public string GetConditionDescription() => "[c/ff9999:Only drops in Adventure Mode]";
+    }
+
+    public class NonAdventureModeRule : IItemDropRuleCondition, IProvideItemConditionDescription {
+        public bool CanDrop(DropAttemptInfo info) => !ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems;
+        public bool CanShowItemDropInUI() => true;
+        public string GetConditionDescription() => "[c/ff9999:Only drops in Non-Adventure Mode]";
     }
 }


### PR DESCRIPTION
General changes:
- VanillaBossBag system massive rework getting rid of obsolete content
- No Dark Souls in reward for beating Lunatic Cultist bugfix
- Craftable Worm Food bugfix
- Droppable Firecracker and Pwnhammer bugfix

Balance changes:
- Queen Slime Mount Saddle has been removed from the corresponding
  Treasure Bag's item pool in order to fix flight availibility
  during pre-Mech stage of the game

Items/BossBags/BossBag.cs changes:
- override the VanillaBossBag.RightClick() method so it now gives
  Dark Souls to a player when they open a Treasure Bag
- get rid of obsolete PreOpenVanillaBag and OpenVanillaBag methods
- modify loot with the VanillaBossBag.ModifyItemLoot() method

NPCs/GlobalNPC.cs changes:
- tsorcRevampWorld.Slain for bosses now starts with 1 and is not
  modified by opening Treasure Bags
- disable tsorcRevampGlobalNPC.ModifyNpcLoot() overriding due to the
  past changes of Rod of Discord's obtaining rules so it wouldn't use
  computing power for no reason

NPCs/VanillaChanges.cs changes:
- override VanillaChanges.ModifyItemLoot() method so Lunatic Cultist now
  drops his own Treasure Bag

tsorcDropRules.cs changes:
- add Item Drop Rule Conditions (FirstBagRule, FirstBagCursedRule,
  AdventureModeRule, NonAdventureModeRule) to manage drops from NPCs
  and Boss Treasure Bags

tsorcRevamp.cs changes:
- add tsorcItemDropRuleConditions with constants to group newly added
  Item Drop Rule Conditions together
- add BossExtras utility enum with masks of first opened Treasure Bags'
  drop rules to help with organization of first bag drop system
- add BossExtrasDescription dictionary which translates BossExtras to
  the dropping conditions and item ids related to them
- add AssignedBossExtras dictionary in order to describe first opened
  Treasure Bags' loot which needs to be unique for all bosses
- add BossBagIDtoNPCID dictionary to easily translate IDs of Boss Bags
  to theirs Boss NPCs IDs respectively
- add RemovedBossBagLoot dictionary to gather all the evidence about
  needed to remove Boss Treasure Bags drops to monitor and control
  changes easily which also provides information for the
  VanillaBossBag.ModifyItemLoot() method
- add AddedBossBagLoot dictionary which contains all of the additions
  to the standard Treasure Bag item drop rules pool to support
  VanillaBossBag.ModifyItemLoot() method

Planned changes:
- rework modded Treasure Bags system and get rid of obsolete content