### PR TITLE
Rework of Modded Treasure Bags

### DIFF
--- a/Items/BossBags/BossBag.cs
+++ b/Items/BossBags/BossBag.cs
@@ -1,26 +1,24 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
+using Terraria.DataStructures;
 using Terraria.ID;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ModLoader;
 using tsorcRevamp;
 using tsorcRevamp.Items.Pets;
 using tsorcRevamp.NPCs.Bosses;
 using tsorcRevamp.NPCs.Bosses.SuperHardMode;
-using Terraria.GameContent.ItemDropRules;
 using System.Collections.Generic;
 
 namespace tsorcRevamp.Items.BossBags
 {
-
     public abstract class BossBag : ModItem
     {
-
         public override void SetStaticDefaults()
         {
             DisplayName.SetDefault("Treasure Bag");
             Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
-
         }
 
         public override void SetDefaults()
@@ -41,7 +39,7 @@ namespace tsorcRevamp.Items.BossBags
         public override bool PreDrawInInventory(SpriteBatch spriteBatch, Vector2 position, Rectangle frame, Color drawColor, Color itemColor, Vector2 origin, float scale)
         {
             Texture2D texture = (Texture2D)Terraria.GameContent.TextureAssets.Item[Item.type];
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i < 4; ++i)
             {
                 Vector2 offsetPositon = Vector2.UnitY.RotatedBy(MathHelper.PiOver2 * i) * 3;
                 spriteBatch.Draw(texture, position + offsetPositon, null, Main.DiscoColor, 0, origin, scale, SpriteEffects.None, 0);
@@ -56,7 +54,7 @@ namespace tsorcRevamp.Items.BossBags
             Texture2D texture = (Texture2D)Terraria.GameContent.TextureAssets.Item[Item.type];
 
             Lighting.AddLight(Item.Center, Main.DiscoColor.ToVector3());
-            for (int i = 0; i < 4; i++)
+            for (int i = 0; i < 4; ++i)
             {
                 Vector2 offsetPositon = Vector2.UnitY.RotatedBy(((Main.GameUpdateCount % 300) / 30f) + MathHelper.PiOver2 * i) * 5;
                 spriteBatch.Draw(texture,offsetPositon + new Vector2(Item.position.X - Main.screenPosition.X + Item.width * 0.5f, Item.position.Y - Main.screenPosition.Y + Item.height - texture.Height * 0.5f + 2f),
@@ -65,13 +63,17 @@ namespace tsorcRevamp.Items.BossBags
 
             return true;
         }
-
     }
 
     #region PreHardMode
 
     public class OolacileDemonBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Ancient Oolacile Demon)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.DragonCrestShield>()));
@@ -79,18 +81,14 @@ namespace tsorcRevamp.Items.BossBags
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.PermanentPotions.PermanentShinePotion>()));
             itemLoot.Add(ItemDropRule.Common(ItemID.CloudinaBottle));
         }
-        
-        public override int BossBagNPC => ModContent.NPCType<AncientOolacileDemon>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before
-        }
     }
-
     public class SlograBag : BossBag
     {
-
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Slogra)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.BurningStone>()));
@@ -98,40 +96,32 @@ namespace tsorcRevamp.Items.BossBags
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Defensive.BloodbiteRing>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Ranged.DarkTrident>()));
         }
-        public override int BossBagNPC => ModContent.NPCType<Slogra>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            tsorcRevampWorld.Slain[ModContent.NPCType<Gaibon>()] = 1;
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before
-            player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<DarkSoul>(), (int)((700 + Main.rand.Next(300)) * tsorcRevampPlayer.CheckSoulsMultiplier(player)));
-        }
     }
     public class GaibonBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Gaibon)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.BurningAura>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Defensive.PoisonbiteRing>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Defensive.BloodbiteRing>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Ranged.DarkTrident>()));
         }
-        public override int BossBagNPC => ModContent.NPCType<Gaibon>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            tsorcRevampWorld.Slain[ModContent.NPCType<Slogra>()] = 1;
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before
-            player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<DarkSoul>(), (int)((700 + Main.rand.Next(300)) * tsorcRevampPlayer.CheckSoulsMultiplier(player)));
-        }
     }
     public class JungleWyvernBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Jungle Wyvern)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.ChloranthyRing>()));
-
             itemLoot.Add(ItemDropRule.Common(ItemID.Amethyst, 1, 2, 10));
             itemLoot.Add(ItemDropRule.Common(ItemID.Topaz, 1, 2, 10));
             itemLoot.Add(ItemDropRule.Common(ItemID.Sapphire, 1, 2, 10));
@@ -140,12 +130,6 @@ namespace tsorcRevamp.Items.BossBags
             itemLoot.Add(ItemDropRule.Common(ItemID.Amber, 1, 2, 10));
             itemLoot.Add(ItemDropRule.Common(ItemID.Diamond, 1, 2, 10));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.JungleWyvern.JungleWyvernHead>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before
-        }
     }
     #endregion
 
@@ -153,125 +137,116 @@ namespace tsorcRevamp.Items.BossBags
 
     public class AncientDemonBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Ancient Demon)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.Accessories.Expert.CrackedDragonStone>(), 1));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.Accessories.EyeOfTheGods>(), 1));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.Accessories.Defensive.BarrierRing>(), 1));
-            itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.Accessories.Expert.CrackedDragonStone>(), 1));
-        }
-
-        public override int BossBagNPC => ModContent.NPCType<AncientDemon>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before
         }
     }
     public class LumeliaBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Hero of Lumelia)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.CovetousSilverSerpentRing>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.SoulShekel>(), 1, 10, 20));
-            itemLoot.Add(ItemDropRule.Common(ItemID.WaterWalkingBoots));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Ammo.ArrowOfBard>(), 1, 10, 20));
-        }
-        public override int BossBagNPC => ModContent.NPCType<HeroofLumelia>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before
+            itemLoot.Add(ItemDropRule.Common(ItemID.WaterWalkingBoots));
         }
     }
     public class TheRageBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (The Rage)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Summon.PhoenixEgg>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<CrestOfFire>()));
             itemLoot.Add(ItemDropRule.Common(ItemID.CobaltDrill));
-        }
-        public override int BossBagNPC => ModContent.NPCType<TheRage>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
         }
     }
     public class TheSorrowBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (The Sorrow)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.GoldenHairpin>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<CrestOfWater>()));
             itemLoot.Add(ItemDropRule.Common(ItemID.AdamantiteDrill));
-        }
-        public override int BossBagNPC => ModContent.NPCType<TheSorrow>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
         }
     }
     public class TheHunterBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (The Hunter)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<CrestOfEarth>()));
             itemLoot.Add(ItemDropRule.Common(ItemID.Drax));
             itemLoot.Add(ItemDropRule.Common(ItemID.WaterWalkingBoots));
         }
-        public override int BossBagNPC => ModContent.NPCType<TheHunter>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
-        }
     }
     public class WyvernMageBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Wyvern Mage)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.Broadswords.LionheartGunblade>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Magic.GemBox>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.LampTome>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HolyWarElixir>(), 1, 2, 2));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.WyvernMage.WyvernMage>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, false, true); //gives the player souls if they haven't opened the bag before          
-        }
     }
     public class SerrisBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Serris)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.DemonDrugPotion>(), 1, 3, 7));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.ArmorDrugPotion>(), 1, 3, 7));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.MagicBarrierScroll>()));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Serris.SerrisX>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true, true); //gives the player souls if they haven't opened the bag before     
-        }
     }
     public class DeathBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Death)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.GreatMagicShieldScroll>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.MagicBarrierScroll>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HolyWarElixir>(), 1, 4, 4));
@@ -279,42 +254,33 @@ namespace tsorcRevamp.Items.BossBags
             itemLoot.Add(ItemDropRule.Common(ItemID.MidnightRainbowDye, 1, 5, 5));
         }
         public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Death>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before            
-        }
     }
     public class MindflayerIllusionBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Mindflayer Illusion)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //won't get an expert item, just a part of Attraidies
-
+            //won't get an expert-exclusive item, just a part of Attraidies
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<BossItems.MindflayerIllusionRelic>()));
-        }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Okiku.ThirdForm.BrokenOkiku>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
         }
     }
     public class AttraidiesBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Attraidies)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.BloomShards>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<HeavenPiercer>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<TheEnd>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<SoulOfAttraidies>(), 1, 15, 23));
-        }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Okiku.FinalForm.Attraidies>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before            
         }
     }
     #endregion
@@ -322,291 +288,210 @@ namespace tsorcRevamp.Items.BossBags
     #region SuperHardMode
     public class KrakenBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Water Fiend Kraken)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.DragoonHorn>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.Shortswords.BarrowBlade>()));
-        }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Fiends.WaterFiendKraken>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true, true); //gives the player souls if they haven't opened the bag before
         }
     }
     public class MarilithBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Fire Fiend Marilith)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.Shortswords.BarrowBlade>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.ForgottenRisingSun>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.Ice3Tome>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<FairyInABottle>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HolyWarElixir>()));
-
-            if (ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems)
-            {
-                itemLoot.Add(ItemDropRule.Common(ItemID.LargeSapphire));
-            }
-        }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Fiends.FireFiendMarilith>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true, true); //gives the player souls if they haven't opened the bag before
+            itemLoot.Add(ItemDropRule.ByCondition(tsorcRevamp.tsorcItemDropRuleConditions.AdventureModeRule, ItemID.LargeSapphire));
         }
     }
     public class LichBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Earth Fiend Lich)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.DragoonBoots>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.Bolt3Tome>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.Broadswords.ForgottenGaiaSword>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HolyWarElixir>()));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.Fiends.EarthFiendLich>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true, true); //gives the player souls if they haven't opened the bag before
-        }
     }
     public class BlightBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Blight)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.DivineSpark>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<SoulOfBlight>(), 1, 3, 6));
-        }
-        public override int BossBagNPC => ModContent.NPCType<Blight>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before           
         }
     }
     public class ChaosBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Chaos)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Magic.FlareTome>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Ranged.ElfinBow>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HolyWarElixir>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<SoulOfChaos>(), 1, 3, 3));
         }
-        public override int BossBagNPC => ModContent.NPCType<Chaos>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before              
-        }
     }
     public class MageShadowBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Wyvern Mage Shadow)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.RingOfPower>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HolyWarElixir>(), 1, 4, 4));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<GhostWyvernSoul>(), 1, 8, 8));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.SuperHardMode.GhostWyvernMage.WyvernMageShadow>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before             
-        }
     }
-
     public class OolacileSorcererBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Abysmal Oolacile Sorcerer)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.DuskCrownRing>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Potions.HealingElixir>(), 1, 10, 10));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<PurgingStone>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Humanity>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<RedTitanite>(), 1, 5, 5));
         }
-        public override int BossBagNPC => ModContent.NPCType<AbysmalOolacileSorcerer>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before           
-        }
     }
     public class ArtoriasBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Artorias)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.RingofArtorias>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Defensive.WolfRing>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<SoulOfArtorias>(), 1, 6, 6));
-            if (ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems)
-            {
-                itemLoot.Add(ItemDropRule.Common(ItemID.LargeAmethyst));
-            }
-        }
-        public override int BossBagNPC => ModContent.NPCType<Artorias>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before
+            itemLoot.Add(ItemDropRule.ByCondition(tsorcRevamp.tsorcItemDropRuleConditions.AdventureModeRule, ItemID.LargeAmethyst));
         }
     }
-
     public class HellkiteBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Hellkite Dragon)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.DragonStone>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<BossItems.HellkiteStone>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.HiRyuuSpear>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<DragonEssence>(), 1, 22, 28));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.Weapons.Melee.Shortswords.BarrowBlade>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Items.SoulShekel>(), 1, 5, 10));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.SuperHardMode.HellkiteDragon.HellkiteDragonHead>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before            
-        }
     }
     public class SeathBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Seath the Scaleless)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.DragonWings>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Defensive.BlueTearstoneRing>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<PurgingStone>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<DragonEssence>(), 1, 35, 40));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<BequeathedSoul>(), 1, 3, 3));
         }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.SuperHardMode.Seath.SeathTheScalelessHead>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
-        }
     }
     public class WitchkingBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Witchking)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.Broadswords.WitchkingsSword>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Armors.Summon.WitchkingHelmet>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Armors.Summon.WitchkingTop>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Armors.Summon.WitchkingBottoms>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Defensive.CovenantOfArtorias>()));
-            if (!ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems)
-            {
-                itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<BrokenStrangeMagicRing>()));
-            }
-        }
-        public override int BossBagNPC => ModContent.NPCType<NPCs.Bosses.SuperHardMode.Witchking>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player, true); //gives the player souls if they haven't opened the bag before
+            itemLoot.Add(ItemDropRule.ByCondition(tsorcRevamp.tsorcItemDropRuleConditions.NonAdventureModeRule, ModContent.ItemType<BrokenStrangeMagicRing>()));
         }
     }
     public class DarkCloudBag : BossBag
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Dark Cloud)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Accessories.Expert.ReflectionShift>()));
-
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Melee.Broadswords.MoonlightGreatsword>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Weapons.Summon.NullSpriteStaff>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<GuardianSoul>(), 1, 5, 5));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Humanity>(), 1, 3, 3));
         }
-        public override int BossBagNPC => ModContent.NPCType<DarkCloud>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
-
-        }
     }
-    public class GwynBag : BossBag
+    public class GwynBag : BossBag 
     {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Treasure Bag (Gwyn, Lord of Cinder)");
+            Tooltip.SetDefault("{$CommonItemTooltip.RightClickToOpen}");
+        }
         public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            //no expert item
-
+            //no expert-exclusive item yet
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Epilogue>()));
             itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<EssenceOfTerraria>()));
-
-
-        }
-        public override int BossBagNPC => ModContent.NPCType<Gwyn>();
-        [System.Obsolete]
-        public override void OpenBossBag(Player player)
-        {
-            VanillaBossBag.AddBossBagSouls(BossBagNPC, player); //gives the player souls if they haven't opened the bag before
-            if (player.GetModPlayer<tsorcRevampPlayer>().BearerOfTheCurse) //threw an error when loading the mod as I tried to put it into modifyitemloot, wouldn't accept Main.player[Main.myplayer].GetModPlayer<tsorcRevampPlayer>().BearerOfTheCurse for the bool
-            {
-                player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<DraxEX>(), 1);
-            }
+            itemLoot.Add(ItemDropRule.ByCondition(tsorcRevamp.tsorcItemDropRuleConditions.CursedRule, ModContent.ItemType<DraxEX>()));
         }
     }
     #endregion
 
     public class VanillaBossBag : GlobalItem
     {
-        public static void AddBossBagSouls(int EnemyID, Player player, bool guardianSoul = false, bool staminaVessel = false)
-        {
-            tsorcRevampPlayer modPlayer = player.GetModPlayer<tsorcRevampPlayer>();
-            if (!modPlayer.bagsOpened.Contains(EnemyID))
-            {
-                modPlayer.bagsOpened.Add(EnemyID);
-            }
-            else
-            {
-                return;
-            }
-
-            NPC npc = new NPC();
-            npc.SetDefaults(EnemyID);
-            float enemyValue = (int)npc.value / 25f;
-            float multiplier = tsorcRevampPlayer.CheckSoulsMultiplier(player);
-            tsorcRevampWorld.Slain[EnemyID] = 1; //set the value to 1
-
-            if (Main.netMode == NetmodeID.Server)
-            {
-                NetMessage.SendData(MessageID.WorldData); //Slain only exists on the server. This tells the server to run NetSend(), which syncs this data with clients
-            }
-
-            int DarkSoulQuantity = (int)(multiplier * enemyValue);
-
-            if (guardianSoul)
-            {
-                player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<GuardianSoul>());
-            }
-            if (staminaVessel)
-            {
-                player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<StaminaVessel>());
-            }
-
-            player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<DarkSoul>(), DarkSoulQuantity);
-        }
-
         public static void GiveDarkSouls(int bossBagID, Player player) {
             tsorcRevampPlayer modPlayer = player.GetModPlayer<tsorcRevampPlayer>();
             if (modPlayer.bagsOpened.Contains(bossBagID)) {
@@ -627,6 +512,10 @@ namespace tsorcRevamp.Items.BossBags
                 return;
             }
 
+            NPC npc = new NPC();
+            npc.SetDefaults(tsorcRevamp.BossBagIDtoNPCID[item.type]);
+            UsefulFunctions.BroadcastText("FullName: " + npc.FullName, Color.Cyan);
+
             GiveDarkSouls(item.type, player);
         }
 
@@ -640,29 +529,31 @@ namespace tsorcRevamp.Items.BossBags
 			int itemID = item.type;
 
             // take into account blocked items
-            List<IItemDropRule> dropRules = loot.Get();
-            foreach (var rule in dropRules) {
-                List<int> ruleItems = new List<int>(){};
-                if (rule is CommonDrop) {
-                    ruleItems.Add(((CommonDrop)rule).itemId);
-                } else if (rule is DropOneByOne) {
-                    ruleItems.Add(((DropOneByOne)rule).itemId);
-                } else if (rule is OneFromOptionsDropRule) {
-                    foreach (var dropId in ((OneFromOptionsDropRule)rule).dropIds) {
-                        ruleItems.Add(dropId);
-                    }
-                } else if (rule is OneFromOptionsNotScaledWithLuckDropRule) {
-                    foreach (var dropId in ((OneFromOptionsNotScaledWithLuckDropRule)rule).dropIds) {
-                        ruleItems.Add(dropId);
-                    }
-                } else {
-                    continue;
-                }
-
-                foreach (var itemToRemove in tsorcRevamp.RemovedBossBagLoot[itemID]) {
-                    if (ruleItems.Contains(itemToRemove)) {
-                        loot.Remove(rule);
+            if (tsorcRevamp.RemovedBossBagLoot.ContainsKey(itemID)) {
+                List<IItemDropRule> dropRules = loot.Get();
+                foreach (var rule in dropRules) {
+                    List<int> ruleItems = new List<int>(){};
+                    if (rule is CommonDrop) {
+                        ruleItems.Add(((CommonDrop)rule).itemId);
+                    } else if (rule is DropOneByOne) {
+                        ruleItems.Add(((DropOneByOne)rule).itemId);
+                    } else if (rule is OneFromOptionsDropRule) {
+                        foreach (var dropId in ((OneFromOptionsDropRule)rule).dropIds) {
+                            ruleItems.Add(dropId);
+                        }
+                    } else if (rule is OneFromOptionsNotScaledWithLuckDropRule) {
+                        foreach (var dropId in ((OneFromOptionsNotScaledWithLuckDropRule)rule).dropIds) {
+                            ruleItems.Add(dropId);
+                        }
+                    } else {
                         continue;
+                    }
+
+                    foreach (var itemToRemove in tsorcRevamp.RemovedBossBagLoot[itemID]) {
+                        if (ruleItems.Contains(itemToRemove)) {
+                            loot.Remove(rule);
+                            continue;
+                        }
                     }
                 }
             }
@@ -676,300 +567,11 @@ namespace tsorcRevamp.Items.BossBags
             }
 
             // add other extra items to Treasure Bags
-            foreach (var dropRule in tsorcRevamp.AddedBossBagLoot[itemID]) {
-                loot.Add(dropRule);
+            if (tsorcRevamp.AddedBossBagLoot.ContainsKey(itemID)) {
+                foreach (var dropRule in tsorcRevamp.AddedBossBagLoot[itemID]) {
+                    loot.Add(dropRule);
+                }
             }
 		}
-
-        public static void SoulsOnFirstBag(int EnemyID, Player player)
-        {
-            var Slain = tsorcRevampWorld.Slain;
-            if (Slain.ContainsKey(EnemyID))
-            {
-                if (Slain[EnemyID] == 0)
-                {
-                    AddBossBagSouls(EnemyID, player);
-                    Slain[EnemyID] = 1;
-                }
-            }
-        }
-
-        public static void StaminaVesselOnFirstBag(int EnemyID, Player player)
-        {
-            var Slain = tsorcRevampWorld.Slain;
-            if (Slain.ContainsKey(EnemyID))
-            {
-                if (Slain[EnemyID] == 0)
-                {
-                    player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<StaminaVessel>());
-                    //Don't set slain to 1, let SoulsOnFirstBag do that as they all run it
-                }
-            }
-        }
-
-        public static void EstusFlaskShardOnFirstBag(int EnemyID, Player player)
-        {
-            var Slain = tsorcRevampWorld.Slain;
-            if (Slain.ContainsKey(EnemyID))
-            {
-                if (Slain[EnemyID] == 0 && player.GetModPlayer<tsorcRevampPlayer>().BearerOfTheCurse)
-                {
-                    player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<EstusFlaskShard>());
-                    //Don't set slain to 1, let SoulsOnFirstBag do that as they all run it
-                }
-            }
-        }
-
-        public static void SublimeBoneDustOnFirstBag(int EnemyID, Player player)
-        {
-            var Slain = tsorcRevampWorld.Slain;
-            if (Slain.ContainsKey(EnemyID))
-            {
-                if (Slain[EnemyID] == 0 && player.GetModPlayer<tsorcRevampPlayer>().BearerOfTheCurse)
-                {
-                    player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<SublimeBoneDust>());
-                    //Don't set slain to 1, let SoulsOnFirstBag do that as they all run it
-                }
-            }
-        }
-        // [System.Obsolete]
-        // public override bool PreOpenVanillaBag(string context, Player player, int arg)
-        // {
-
-        //     if (context == "bossBag" && arg == ItemID.KingSlimeBossBag)
-        //     { //re-implement king slime bag to stop blacklisted items from dropping in adventure mode
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ItemID.RoyalGel);
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ItemID.Solidifier);
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ItemID.GoldCoin, 11);
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ItemID.Katana);
-        //         if (Main.rand.Next(99) < 66) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.NinjaHood); }
-        //         if (Main.rand.Next(99) < 66) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.NinjaShirt); }
-        //         if (Main.rand.Next(99) < 66) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.NinjaPants); }
-        //         if (Main.rand.NextBool(7)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.KingSlimeMask); }
-        //         if (Main.rand.NextBool(10)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.KingSlimeTrophy); }
-        //         if (Main.rand.NextBool(2)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.SlimeGun); }
-        //         //player.QuickSpawnItem(player.GetSource_Loot(), ItemID.SlimySaddle); //didn't want such a powerful mobility tool obtainable from such a relatively easy, early-game mini-boss; also wanted sequence breaking to be done via the map if they found it rather than vanilla terraria knowledge
-        //         if (Main.rand.NextBool(2)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.SlimeHook); }
-
-        //         StaminaVesselOnFirstBag(NPCID.KingSlime, player);
-        //         SoulsOnFirstBag(NPCID.KingSlime, player);
-        //         return false;
-        //     }
-        //     if (context == "bossBag" && arg == ItemID.GolemBossBag)
-        //     {
-        //         //Picksaw drops from Attraidies who is Post-Golem now, and gates SuperHardMode content. We've gotta stop Golem from dropping it.
-        //         if (!ModContent.GetInstance<tsorcRevampConfig>().AdventureModeItems)
-        //         {
-        //             if (Main.rand.NextBool(3)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.Picksaw); }
-        //         }
-        //         else
-        //         {
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<Items.BrokenPicksaw>());
-        //         }
-
-        //         //Drops that work in the traditional way. Also, adds the Crest of Stone to its drops.
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<CrestOfStone>());
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ItemID.ShinyStone);
-        //         if (Main.rand.NextBool(6)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.GolemMask); }
-        //         if (Main.rand.NextBool(9)) { player.QuickSpawnItem(player.GetSource_Loot(), ItemID.GolemTrophy); }
-        //         player.QuickSpawnItem(player.GetSource_Loot(), ItemID.GreaterHealingPotion, 5 + Main.rand.Next(10));
-
-        //         //Always drops one of these things, picked at random
-        //         int drop = Main.rand.Next(6);
-        //         switch (drop)
-        //         {
-        //             case 0:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.Stynger);
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.StyngerBolt, 60 + Main.rand.Next(39));
-        //                 break;
-        //             case 1:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.PossessedHatchet);
-        //                 break;
-        //             case 2:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.SunStone);
-        //                 break;
-        //             case 3:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.EyeoftheGolem);
-        //                 break;
-        //             case 4:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.HeatRay);
-        //                 break;
-        //             case 5:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.StaffofEarth);
-        //                 break;
-        //             case 6:
-        //                 player.QuickSpawnItem(player.GetSource_Loot(), ItemID.GolemFist);
-        //                 break;
-        //         }
-
-        //         SoulsOnFirstBag(NPCID.Golem, player);
-        //         return false;
-        //     }
-
-
-
-        //     return base.PreOpenVanillaBag(context, player, arg);
-        // }
-        // public override void OpenVanillaBag(string context, Player player, int arg)
-        // {
-        //     var Slain = tsorcRevampWorld.Slain;
-        //     if (context == "bossBag")
-        //     {
-        //         if (arg == ItemID.EyeOfCthulhuBossBag)
-        //         {
-        //             UsefulFunctions.BroadcastText("Open", Color.Cyan);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ItemID.HermesBoots);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ItemID.HerosHat);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ItemID.HerosPants);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ItemID.HerosShirt);
-        //             SublimeBoneDustOnFirstBag(NPCID.EyeofCthulhu, player);
-        //             SoulsOnFirstBag(NPCID.EyeofCthulhu, player);
-        //         }
-        //         if (arg == ItemID.EaterOfWorldsBossBag)
-        //         {
-        //             SoulsOnFirstBag(NPCID.EaterofWorldsHead, player);
-        //         }
-        //         if (arg == ItemID.BrainOfCthulhuBossBag)
-        //         {
-        //             StaminaVesselOnFirstBag(NPCID.BrainofCthulhu, player);
-        //             SoulsOnFirstBag(NPCID.BrainofCthulhu, player);
-        //         }
-        //         if (arg == ItemID.QueenBeeBossBag)
-        //         {
-        //             if (Slain.ContainsKey(NPCID.QueenBee))
-        //             {
-        //                 if (Slain[NPCID.QueenBee] == 0)
-        //                 {
-        //                     VanillaBossBag.AddBossBagSouls(NPCID.QueenBee, player, false, true);
-        //                     Slain[NPCID.QueenBee] = 1;
-        //                 }
-        //             };
-        //         }
-        //         if (arg == ItemID.WallOfFleshBossBag)
-        //         {
-        //             EstusFlaskShardOnFirstBag(NPCID.WallofFlesh, player);
-        //             SoulsOnFirstBag(NPCID.WallofFlesh, player);
-        //         }
-        //         if (arg == ItemID.SkeletronBossBag)
-        //         {
-        //             SublimeBoneDustOnFirstBag(NPCID.SkeletronHead, player);
-        //             SoulsOnFirstBag(NPCID.SkeletronHead, player);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<MiakodaFull>());
-        //         }
-        //         if (arg == ItemID.DestroyerBossBag)
-        //         {
-        //             SoulsOnFirstBag(NPCID.TheDestroyer, player);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<RTQ2>());
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<CrestOfCorruption>(), 1);
-        //         }
-        //         if (arg == ItemID.TwinsBossBag)
-        //         {
-        //             /* 
-        //             * picture the following:
-        //             * Twins are killed. Spazmatism is added to Slain, and the player opens a bag and receives souls
-        //             * then, Twins are killed again. Retinazer is added to slain this time, and the player opens a bag and gets souls again
-        //             * to prevent this, we need to make sure we haven't opened a bag from Spazmatism when we open a bag in Retinazer's context
-        //             */
-        //             if (Slain.ContainsKey(NPCID.Retinazer))
-        //             {
-        //                 if (Slain[NPCID.Retinazer] == 0)
-        //                 {
-        //                     bool SpazmatismDowned = Slain.TryGetValue(NPCID.Spazmatism, out int value);
-        //                     //if SpazmatismDowned evaluates to true, int value is set to the value pair of Spazmatism's key, which stores if a bag has been opened
-        //                     if (!SpazmatismDowned || value == 0)
-        //                     { //if Spazmatism is not in Slain, or no twins bag has been opened in Spazmatism's context
-        //                         AddBossBagSouls(NPCID.Retinazer, player);
-        //                         Slain[NPCID.Retinazer] = 1;
-        //                     }
-        //                 }
-        //             }
-        //             else if (Slain.ContainsKey(NPCID.Spazmatism))
-        //             { //dont need to check if Retinazer is downed, since this is only run if Retinazer is not in Slain
-        //                 if (Slain[NPCID.Spazmatism] == 0)
-        //                 {
-        //                     AddBossBagSouls(NPCID.Spazmatism, player);
-        //                     Slain[NPCID.Spazmatism] = 1;
-        //                 }
-        //             }
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<CrestOfSky>(), 1);
-        //         }
-        //         if (arg == ItemID.SkeletronPrimeBossBag)
-        //         {
-        //             SublimeBoneDustOnFirstBag(NPCID.SkeletronPrime, player);
-        //             SoulsOnFirstBag(NPCID.SkeletronPrime, player);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ItemID.AngelWings);
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<CrestOfSteel>(), 1);
-        //         }
-        //         if (arg == ItemID.PlanteraBossBag)
-        //         {
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<CrestOfLife>());
-        //             player.QuickSpawnItem(player.GetSource_Loot(), ModContent.ItemType<SoulOfLife>(), 3);
-        //             SoulsOnFirstBag(NPCID.Plantera, player);
-        //         }
-        //         if (arg == ItemID.FishronBossBag)
-        //         {
-        //             StaminaVesselOnFirstBag(NPCID.DukeFishron, player);
-        //             SoulsOnFirstBag(NPCID.DukeFishron, player);
-        //         }
-        //         if (arg == ItemID.BossBagBetsy)
-        //         {
-        //             SoulsOnFirstBag(NPCID.DD2Betsy, player);
-        //         }
-        //         if (arg == ItemID.MoonLordBossBag)
-        //         {
-        //             if (Slain.ContainsKey(NPCID.MoonLordCore))
-        //             {
-        //                 if (Slain[NPCID.MoonLordCore] == 0)
-        //                 {
-        //                     SoulsOnFirstBag(NPCID.MoonLordCore, player); //idk why but there was a lot of seemingly unnecessary code here, Moon Lord will just drop his souls according to his Cores value like this once
-        //                 }
-        //             }
-        //         }
-        //         if (arg == ItemID.QueenSlimeBossBag)
-        //         {
-        //             if (Slain.ContainsKey(NPCID.QueenSlimeBoss))
-        //             {
-        //                 if (Slain[NPCID.QueenSlimeBoss] == 0)
-        //                 {
-        //                     VanillaBossBag.AddBossBagSouls(NPCID.QueenSlimeBoss, player, false, true);
-        //                     Slain[NPCID.QueenSlimeBoss] = 1;
-        //                 }
-        //             };
-        //         }
-        //         if (arg == ItemID.FairyQueenBossBag)
-        //         {
-        //             if (Slain.ContainsKey(NPCID.HallowBoss))
-        //             {
-        //                 if (Slain[NPCID.HallowBoss] == 0)
-        //                 {
-        //                     VanillaBossBag.AddBossBagSouls(NPCID.HallowBoss, player, false, true);
-        //                     Slain[NPCID.HallowBoss] = 1;
-        //                 }
-        //             };
-        //         }
-        //         if (arg == ItemID.BossBagBetsy)
-        //         {
-        //             if (Slain.ContainsKey(NPCID.DD2Betsy))
-        //             {
-        //                 if (Slain[NPCID.DD2Betsy] == 0)
-        //                 {
-        //                     VanillaBossBag.AddBossBagSouls(NPCID.DD2Betsy, player, false, true);
-        //                     Slain[NPCID.DD2Betsy] = 1;
-        //                 }
-        //             };
-        //         }
-        //         if (arg == ItemID.DeerclopsBossBag)
-        //         {
-        //             if (Slain.ContainsKey(NPCID.Deerclops))
-        //             {
-        //                 if (Slain[NPCID.Deerclops] == 0)
-        //                 {
-        //                     VanillaBossBag.AddBossBagSouls(NPCID.Deerclops, player, false, true);
-        //                     Slain[NPCID.Deerclops] = 1;
-        //                 }
-        //             };
-        //         }
-        //     }
-        // }
     }
 }

--- a/tsorcDropRules.cs
+++ b/tsorcDropRules.cs
@@ -32,7 +32,7 @@ namespace tsorcRevamp {
         public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info) {
             ItemDropAttemptResult result = default;
             if (info.player.RollLuck(_chanceDenominator) < _chanceNumerator) {
-                for (int i = 0; i < _drops.Length; i++) {
+                for (int i = 0; i < _drops.Length; ++i) {
                     CommonCode.DropItem(info, _drops[i], 1);
                 }
                 result.State = ItemDropAttemptResultState.Success;
@@ -45,7 +45,7 @@ namespace tsorcRevamp {
         public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo) {
             float origRate = (float)_chanceNumerator / (float)_chanceDenominator;
             float totalRate = origRate * ratesInfo.parentDroprateChance;
-            for (int i = 0; i < _drops.Length; i++) {
+            for (int i = 0; i < _drops.Length; ++i) {
                 drops.Add(new DropRateInfo(_drops[i], 1, 1, totalRate, ratesInfo.conditions));
             }
             Chains.ReportDroprates(ChainedRules, origRate, drops, ratesInfo);
@@ -61,10 +61,7 @@ namespace tsorcRevamp {
     public class FirstBagRule : IItemDropRuleCondition, IProvideItemConditionDescription {
         public virtual bool CanDrop(DropAttemptInfo info) {
             tsorcRevampPlayer modPlayer = info.player.GetModPlayer<tsorcRevampPlayer>();
-            if (modPlayer.bagsOpened.Contains(info.item)) {
-                return false;
-            }
-            return true;
+            return !modPlayer.bagsOpened.Contains(info.item);
         }
 
         public bool CanShowItemDropInUI() => true;
@@ -72,13 +69,21 @@ namespace tsorcRevamp {
         public virtual string GetConditionDescription() => "[c/ff9999: Only drops from the first opened specific Bag";
     }
 
+    public class CursedRule : IItemDropRuleCondition, IProvideItemConditionDescription {
+        public virtual bool CanDrop(DropAttemptInfo info) {
+            tsorcRevampPlayer modPlayer = info.player.GetModPlayer<tsorcRevampPlayer>();
+            return modPlayer.BearerOfTheCurse;
+        }
+
+        public bool CanShowItemDropInUI() => true;
+
+        public virtual string GetConditionDescription() => "[c/ff9999: Only drops when the player is a Bearer of the Curse";
+    }
+
     public class FirstBagCursedRule : FirstBagRule {
         public override bool CanDrop(DropAttemptInfo info) {
             tsorcRevampPlayer modPlayer = info.player.GetModPlayer<tsorcRevampPlayer>();
-            if (modPlayer.BearerOfTheCurse & base.CanDrop(info)) {
-                return true;
-            }
-            return false;
+            return modPlayer.BearerOfTheCurse & base.CanDrop(info);
         }
 
         public override string GetConditionDescription() => "[c/ff9999: Only drops from the first opened specific Bag while the player is a Bearer of the Curse";

--- a/tsorcRevamp.cs
+++ b/tsorcRevamp.cs
@@ -23,7 +23,10 @@ using Terraria.ModLoader;
 using Terraria.ModLoader.IO;
 using Terraria.UI;
 using tsorcRevamp.Items;
+using tsorcRevamp.Items.BossBags;
 using tsorcRevamp.Items.Pets;
+using tsorcRevamp.NPCs.Bosses;
+using tsorcRevamp.NPCs.Bosses.SuperHardMode;
 using tsorcRevamp.UI;
 using static tsorcRevamp.ILEdits;
 using static tsorcRevamp.MethodSwaps;
@@ -34,8 +37,9 @@ namespace tsorcRevamp
     {
         public class tsorcItemDropRuleConditions 
         {
-            public static IItemDropRuleCondition FirstBagRule;
             public static IItemDropRuleCondition SuperHardmodeRule;
+            public static IItemDropRuleCondition FirstBagRule;
+            public static IItemDropRuleCondition CursedRule;
             public static IItemDropRuleCondition FirstBagCursedRule;
             public static IItemDropRuleCondition AdventureModeRule;
             public static IItemDropRuleCondition NonAdventureModeRule;
@@ -182,8 +186,9 @@ namespace tsorcRevamp
         private void PopulateArrays()
         {
             #region tsorcItemDropRuleConditions class
-            tsorcItemDropRuleConditions.FirstBagRule = new FirstBagRule();
             tsorcItemDropRuleConditions.SuperHardmodeRule = new SuperHardmodeRule();
+            tsorcItemDropRuleConditions.FirstBagRule = new FirstBagRule();
+            tsorcItemDropRuleConditions.CursedRule = new CursedRule();
             tsorcItemDropRuleConditions.FirstBagCursedRule = new FirstBagCursedRule();
             tsorcItemDropRuleConditions.AdventureModeRule = new AdventureModeRule();
             tsorcItemDropRuleConditions.NonAdventureModeRule = new NonAdventureModeRule();
@@ -618,6 +623,7 @@ namespace tsorcRevamp
             #region AssignedBossExtras dictionary
             AssignedBossExtras = new Dictionary<int, BossExtras>() 
             {   
+                #region Vanilla
                 {   ItemID.KingSlimeBossBag         , BossExtras.StaminaVessel      },
                 {   ItemID.EyeOfCthulhuBossBag      , BossExtras.StaminaVessel  
                                                     | BossExtras.SublimeBoneDust    },
@@ -637,7 +643,42 @@ namespace tsorcRevamp
                 {   ItemID.QueenSlimeBossBag        , BossExtras.DarkSoulsOnly      },
                 {   ItemID.FairyQueenBossBag        , BossExtras.DarkSoulsOnly      },
                 {   ItemID.BossBagBetsy             , BossExtras.DarkSoulsOnly      },
-                {   ItemID.DeerclopsBossBag         , BossExtras.DarkSoulsOnly      }
+                {   ItemID.DeerclopsBossBag         , BossExtras.DarkSoulsOnly      },
+                #endregion
+                //--------
+                #region tsorc
+                {   ModContent.ItemType<OolacileDemonBag>()         , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<SlograBag>()                , BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<GaibonBag>()                , BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<JungleWyvernBag>()          , BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<AncientDemonBag>()          , BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<LumeliaBag>()               , BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<TheRageBag>()               , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<TheSorrowBag>()             , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<TheHunterBag>()             , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<WyvernMageBag>()            , BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<SerrisBag>()                , BossExtras.GuardianSoul
+                                                                    | BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<DeathBag>()                 , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<MindflayerIllusionBag>()    , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<AttraidiesBag>()            , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<KrakenBag>()                , BossExtras.GuardianSoul
+                                                                    | BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<MarilithBag>()              , BossExtras.GuardianSoul
+                                                                    | BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<LichBag>()                  , BossExtras.GuardianSoul
+                                                                    | BossExtras.StaminaVessel      },
+                {   ModContent.ItemType<BlightBag>()                , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<ChaosBag>()                 , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<MageShadowBag>()            , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<OolacileSorcererBag>()      , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<ArtoriasBag>()              , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<HellkiteBag>()              , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<SeathBag>()                 , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<WitchkingBag>()             , BossExtras.GuardianSoul       },
+                {   ModContent.ItemType<DarkCloudBag>()             , BossExtras.DarkSoulsOnly      },
+                {   ModContent.ItemType<GwynBag>()                  , BossExtras.DarkSoulsOnly      }
+                #endregion
             };
             #endregion
             //--------
@@ -654,6 +695,7 @@ namespace tsorcRevamp
             #region BossBagIDtoNPCID dictionary
             BossBagIDtoNPCID = new Dictionary<int, int>() 
             {
+                #region Vanilla
                 {   ItemID.KingSlimeBossBag         , NPCID.KingSlime           },
                 {   ItemID.EyeOfCthulhuBossBag      , NPCID.EyeofCthulhu        },
                 {   ItemID.EaterOfWorldsBossBag     , NPCID.EaterofWorldsHead   },
@@ -672,13 +714,45 @@ namespace tsorcRevamp
                 {   ItemID.QueenSlimeBossBag        , NPCID.QueenSlimeBoss      },
                 {   ItemID.FairyQueenBossBag        , NPCID.HallowBoss          },
                 {   ItemID.BossBagBetsy             , NPCID.DD2Betsy            },
-                {   ItemID.DeerclopsBossBag         , NPCID.Deerclops           }
+                {   ItemID.DeerclopsBossBag         , NPCID.Deerclops           },
+                #endregion
+                //--------
+                #region tsorc
+                {   ModContent.ItemType<OolacileDemonBag>()         , ModContent.NPCType<AncientOolacileDemon>()                                        },
+                {   ModContent.ItemType<SlograBag>()                , ModContent.NPCType<Slogra>()                                                      },
+                {   ModContent.ItemType<GaibonBag>()                , ModContent.NPCType<Gaibon>()                                                      },
+                {   ModContent.ItemType<JungleWyvernBag>()          , ModContent.NPCType<NPCs.Bosses.JungleWyvern.JungleWyvernHead>()                   },
+                {   ModContent.ItemType<AncientDemonBag>()          , ModContent.NPCType<AncientDemon>()                                                },
+                {   ModContent.ItemType<LumeliaBag>()               , ModContent.NPCType<HeroofLumelia>()                                               },
+                {   ModContent.ItemType<TheRageBag>()               , ModContent.NPCType<TheRage>()                                                     },
+                {   ModContent.ItemType<TheSorrowBag>()             , ModContent.NPCType<TheSorrow>()                                                   },
+                {   ModContent.ItemType<TheHunterBag>()             , ModContent.NPCType<TheHunter>()                                                   },      
+                {   ModContent.ItemType<WyvernMageBag>()            , ModContent.NPCType<NPCs.Bosses.WyvernMage.WyvernMage>()                           },     
+                {   ModContent.ItemType<SerrisBag>()                , ModContent.NPCType<NPCs.Bosses.Serris.SerrisX>()                                  },     
+                {   ModContent.ItemType<DeathBag>()                 , ModContent.NPCType<NPCs.Bosses.Death>()                                           },
+                {   ModContent.ItemType<MindflayerIllusionBag>()    , ModContent.NPCType<NPCs.Bosses.Okiku.ThirdForm.BrokenOkiku>()                     },
+                {   ModContent.ItemType<AttraidiesBag>()            , ModContent.NPCType<NPCs.Bosses.Okiku.FinalForm.Attraidies>()                      },
+                {   ModContent.ItemType<KrakenBag>()                , ModContent.NPCType<NPCs.Bosses.Fiends.WaterFiendKraken>()                         },
+                {   ModContent.ItemType<MarilithBag>()              , ModContent.NPCType<NPCs.Bosses.Fiends.FireFiendMarilith>()                        },
+                {   ModContent.ItemType<LichBag>()                  , ModContent.NPCType<NPCs.Bosses.Fiends.EarthFiendLich>()                           },
+                {   ModContent.ItemType<BlightBag>()                , ModContent.NPCType<Blight>()                                                      },
+                {   ModContent.ItemType<ChaosBag>()                 , ModContent.NPCType<Chaos>()                                                       },
+                {   ModContent.ItemType<MageShadowBag>()            , ModContent.NPCType<NPCs.Bosses.SuperHardMode.GhostWyvernMage.WyvernMageShadow>()  },
+                {   ModContent.ItemType<OolacileSorcererBag>()      , ModContent.NPCType<AbysmalOolacileSorcerer>()                                     },
+                {   ModContent.ItemType<ArtoriasBag>()              , ModContent.NPCType<Artorias>()                                                    },
+                {   ModContent.ItemType<HellkiteBag>()              , ModContent.NPCType<NPCs.Bosses.SuperHardMode.HellkiteDragon.HellkiteDragonHead>() },
+                {   ModContent.ItemType<SeathBag>()                 , ModContent.NPCType<NPCs.Bosses.SuperHardMode.Seath.SeathTheScalelessHead>()       },
+                {   ModContent.ItemType<WitchkingBag>()             , ModContent.NPCType<NPCs.Bosses.SuperHardMode.Witchking>()                         },
+                {   ModContent.ItemType<DarkCloudBag>()             , ModContent.NPCType<DarkCloud>()                                                   },
+                {   ModContent.ItemType<GwynBag>()                  , ModContent.NPCType<Gwyn>()                                                        }
+                #endregion
             };
             #endregion
             //--------
             #region RemovedBossBagLoot dictionary
             RemovedBossBagLoot = new Dictionary<int, List<int>>()
             {
+                #region Vanilla
                 {   ItemID.KingSlimeBossBag         ,   new List<int>()
                                                         {
                                                             ItemID.SlimySaddle
@@ -711,12 +785,14 @@ namespace tsorcRevamp
                 {   ItemID.FairyQueenBossBag        ,   new List<int>()                     },
                 {   ItemID.BossBagBetsy             ,   new List<int>()                     },
                 {   ItemID.DeerclopsBossBag         ,   new List<int>()                     }
+                #endregion
             };
             #endregion
             //--------
             #region AddedBossBagLoot dictionary
             AddedBossBagLoot = new Dictionary<int, List<IItemDropRule>>() 
             {
+                #region Vanilla
                 {   ItemID.KingSlimeBossBag         ,   new List<IItemDropRule>()                                                        },
                 {   ItemID.EyeOfCthulhuBossBag      ,   new List<IItemDropRule>()                           
                                                         {
@@ -769,8 +845,11 @@ namespace tsorcRevamp
                 {   ItemID.FairyQueenBossBag        ,   new List<IItemDropRule>()                                                        },
                 {   ItemID.BossBagBetsy             ,   new List<IItemDropRule>()                                                        },
                 {   ItemID.DeerclopsBossBag         ,   new List<IItemDropRule>()                                                        }
+                #endregion
             };
             #endregion
+            //--------
+
             //--------
             #region CustomDungeonTiles list
             CustomDungeonWalls = new bool[231];
@@ -788,8 +867,9 @@ namespace tsorcRevamp
 
         public override void Unload()
         {
-            tsorcItemDropRuleConditions.FirstBagRule            = null;
             tsorcItemDropRuleConditions.SuperHardmodeRule       = null;
+            tsorcItemDropRuleConditions.FirstBagRule            = null;
+            tsorcItemDropRuleConditions.CursedRule              = null;
             tsorcItemDropRuleConditions.FirstBagCursedRule      = null;
             tsorcItemDropRuleConditions.AdventureModeRule       = null;
             tsorcItemDropRuleConditions.NonAdventureModeRule    = null;


### PR DESCRIPTION
General changes:
- refactor and get rid of obsolete content completely
- add descriptions (bosses's names) to the Treasure Bags' names so now
  the player won't be that confused while having a lot of different
  bags in their inventory

Balance changes:
- Slogra and Gaibon now do not drop any extra Dark Souls from their
  Treasure Bags

tsorcDropRules.cs changes:
- add CursedRule ItemDropRuleCondition which states whether a player is
  the Bearer of the Curse or not

tsorcRevamp.cs changes:
- add modded boss rules and content to
  BossBagIDtoNPCID and AssignedBossExtras dictionaries
- add Vanilla and tsorc regions to the dictionaries to improve code's
  readability

BossBag.cs changes:
- refactor and make the VanillaBossBag's class code compatible with
  modded boss content
- optimize the code a bit