### PR TITLE
Remove vestigial code from Spazmatism's teleport

### DIFF
--- a/NPCs/Bosses/SpazmatismV2.cs
+++ b/NPCs/Bosses/SpazmatismV2.cs
@@ -50,7 +50,7 @@ namespace tsorcRevamp.NPCs.Bosses
 
         public override void SetStaticDefaults()
         {
-            DisplayName.SetDefault("Spazmatism v2.14");
+            DisplayName.SetDefault("Spazmatism v2.15");
         }
 
         int FireJetDamage = 40;
@@ -134,14 +134,6 @@ namespace tsorcRevamp.NPCs.Bosses
             if (!HandleLife())
             {
                 return;
-            }
-                        
-            //Teleport if too far away
-            if (NPC.Distance(target.Center) > 4000 && finalStandTimer == 0)
-            {
-                //NPC.Center = target.Center + new Vector2(0, 1000);
-                NPC.netUpdate = true;
-                UsefulFunctions.BroadcastText("Spazmatism Closes In...");
             }
 
             //Initialize move list


### PR DESCRIPTION
Spazmatism V2 would previously teleport to the player when too far away, and show a message in chat when doing so. The teleport was commented out, but the chat message was not, so getting too far away from Spazmatism would show the message in chat every frame, possibly making the player miss other important chat messages.

Since the code is commented out anyway, I went ahead and just deleted the if-statement in question.