### PR TITLE
Fixed the VillageMIrror OutOfBounds message

### DIFF
--- a/Items/Tools/VillageMirror.cs
+++ b/Items/Tools/VillageMirror.cs
@@ -35,19 +35,19 @@ namespace tsorcRevamp.Items.Tools
                 Main.NewText(LangUtils.GetTextValue("CommonItemTooltip.UnusableDuringBoss"), Color.Yellow);
                 return false;
             }
-            if (!player.GetModPlayer<tsorcRevampPlayer>().BearerOfTheCurse)
+            /*if (!player.GetModPlayer<tsorcRevampPlayer>().BearerOfTheCurse)
+            {*/
+            if (!player.GetModPlayer<tsorcRevampPlayer>().townWarpSet)
             {
-                if (!player.GetModPlayer<tsorcRevampPlayer>().townWarpSet)
-                {
-                    Main.NewText(LangUtils.GetTextValue("Items.GreatMagicMirror.NoLocation"), 255, 240, 20);
-                    return false;
-                }
-                else if (player.GetModPlayer<tsorcRevampPlayer>().townWarpWorld != Main.worldID)
-                {
-                    Main.NewText(LangUtils.GetTextValue("Items.GreatMagicMirror.WrongWorld"), 255, 240, 20);
-                    return false;
-                }
+                Main.NewText(LangUtils.GetTextValue("Items.GreatMagicMirror.NoLocation"), 255, 240, 20);
+                return false;
             }
+            else if (player.GetModPlayer<tsorcRevampPlayer>().townWarpWorld != Main.worldID)
+            {
+                Main.NewText(LangUtils.GetTextValue("Items.GreatMagicMirror.WrongWorld"), 255, 240, 20);
+                return false;
+            }
+            //}
             return base.CanUseItem(player);
         }
         public override void UseStyle(Player player, Rectangle rectangle)


### PR DESCRIPTION
Fixed the issue of Village mirror writing out the out of bounds message if a bearer of the curse player has not set a teleport location yet.
Issue: Fixes #55 