### PR TITLE
Update SummonerEdits.cs  Finch/BabyBird update.   Should now allow summoning of twice as many BabyBirds that are weaker.

### DIFF
--- a/Items/VanillaItems/SummonerEdits.cs
+++ b/Items/VanillaItems/SummonerEdits.cs
@@ -24,7 +24,11 @@ namespace tsorcRevamp.Items.VanillaItems
             }
             if (item.type == ItemID.BabyBirdStaff)
             {
-                item.damage = 6;
+                item.damage = 3;
+            }
+            if (item.type == ItemID.BabyBirdStaff)
+            {
+                float SlotsRequired = 0.5f;
             }
             if (item.type == ItemID.SlimeStaff)
             {

--- a/Items/VanillaItems/SummonerEdits.cs
+++ b/Items/VanillaItems/SummonerEdits.cs
@@ -26,9 +26,9 @@ namespace tsorcRevamp.Items.VanillaItems
             {
                 item.damage = 3;
             }
-            if (item.type == ItemID.BabyBirdStaff)
+            if (entity.type == ProjectileID.BabyBird)
             {
-                float SlotsRequired = 0.5f;
+                entity.minionSlots = 2f;
             }
             if (item.type == ItemID.SlimeStaff)
             {


### PR DESCRIPTION
my second attempt at editing.  suggesting lower Finch/baby bird staff staff summon damage from 6 to 2 while changing the number of minion slots required from 1 to 0.5.  (hopefully i have the code correct to change the slots required using IF command).

The intent with this is my initial start to trying to offer balancing to summon minions (as ghost/those that go through wall types overshadow the rest).

By lowering damage and increasing total minions this offers the Finch staff as a summon staff early game that prefers summoning multiple weak minions.