### PR TITLE
Update SummonerEdits.cs

### DIFF
--- a/Items/VanillaItems/SummonerEdits.cs
+++ b/Items/VanillaItems/SummonerEdits.cs
@@ -30,6 +30,10 @@ namespace tsorcRevamp.Items.VanillaItems
             {
                 item.damage = 7;
             }
+            if (item.type == ProjectileType<BabySlime>)
+            {
+                target.AddBuff(BuffID.Confused, 30);
+            }
             if (item.type == ItemID.FlinxStaff)
             {
                 item.damage = 6;


### PR DESCRIPTION
Attempting to improve summon weapons.  This one is for Slime Minion. Adding 30 frames (0.5 seconds) of confused debuff.  Hopefully i have the code correct to add the buff/debuff to the "baby Slime" projectile (which should be the ID) so that the code will make it so when the slime hits an enemy it will add 0.5 seconds of confusion.   Just long enough to temporarily pause an enemy.  Can be shortened further if needed. Would prefer a "slowing" type debuff but not sure if existing "slow" debuff works on enemy mobs.

This should make it more valuable in comparison the Abigals Flower which can go through walls and hit anything.