### PR TITLE
Patch 3 Babyslime debuff slow and Flinx Frostburn Debuff

### DIFF
--- a/Items/VanillaItems/SummonerEdits.cs
+++ b/Items/VanillaItems/SummonerEdits.cs
@@ -32,7 +32,7 @@ namespace tsorcRevamp.Items.VanillaItems
             }
             if (item.type == ItemID.FlinxStaff)
             {
-                item.damage = 6;
+                item.damage = 1;
             }
             if (item.type == ItemID.VampireFrogStaff)
             {

--- a/Projectiles/tsorcGlobalProjectile.cs
+++ b/Projectiles/tsorcGlobalProjectile.cs
@@ -397,6 +397,16 @@ namespace tsorcRevamp.Projectiles
             {
                 target.AddBuff(ModContent.BuffType<Buffs.CrescentMoonlight>(), 3 * 60); // Adds the ExampleJavelin debuff for a very small DoT
             }
+            
+            if (projectile.type == ProjectileID.BabySlime)
+            {
+                target.AddBuff(BuffID.Slow, 60);
+            }
+
+            if (projectile.type == ProjectileID.FlinxMinion)
+            {
+                target.AddBuff(BuffID.Frostburn, 60);
+            }
 
             if (projectile.owner == Main.myPlayer && !projectile.hostile && modPlayer.MiakodaNewBoost && projectile.type != (int)ModContent.ProjectileType<MiakodaNew>())
             {


### PR DESCRIPTION
Adjustments to balance out early game summons.   BabySlime will have a slowing debuff as a utillity while Flinx will lose direct contact damage in trade for Frostburn Debuff as a utility option for an early game summon to deal with high defense creatures by way of debuff. 

This should help underutilized early game summons as alternative options in comparison of the raw power of Abigals Flower which bypasses walls. 