### PR TITLE
Update AshenLord.cs   size of dragon

### DIFF
--- a/Projectiles/Summon/Runeterra/Dragons/AshenLord/AshenLord.cs
+++ b/Projectiles/Summon/Runeterra/Dragons/AshenLord/AshenLord.cs
@@ -11,7 +11,7 @@ namespace tsorcRevamp.Projectiles.Summon.Runeterra.Dragons
 {
     public class AshenLord : RuneterraDragon
     {
-        public override float Scale => 1f;
+        public override float Scale => 0.25f;
         public override int BuffType => ModContent.BuffType<CenterOfTheHeat>();
         public override int DebuffType => ModContent.BuffType<ScorchingDebuff>();
         public override int PairedProjectileType => ModContent.ProjectileType<ScorchingPointFireball>();


### PR DESCRIPTION
The float scale should adjust the entire dragon (segments included) visually to be smaller. While the segments in the code appear to be at "set" locations when creating (as each one as animation on it's own) the float scale should be the device/code (as i understand) that then scales the entirety of the formed dragon as a whole piece. It's functions would remain the same.  

In summary: The float scale should adjust the total dragon, positional segments (arm/legs) included (x and y locations), to be smaller.