### PR TITLE
Update OrbOfDeception.cs damage and mana cost reduction 20%

### DIFF
--- a/Items/Weapons/Magic/Runeterra/OrbOfDeception.cs
+++ b/Items/Weapons/Magic/Runeterra/OrbOfDeception.cs
@@ -11,8 +11,8 @@ namespace tsorcRevamp.Items.Weapons.Magic.Runeterra
     {
         public override int Width => 32;
         public override int Height => 32;
-        public override int Damage => 22;
-        public override int ManaCost => 25;
+        public override int Damage => 18;
+        public override int ManaCost => 20;
         public override int Rarity => ItemRarityID.Green;
         public override int Value => Item.buyPrice(0, 10, 0, 0);
         public override int HeldOrbProjectile => ModContent.ProjectileType<HeldOrbOfDeception>();


### PR DESCRIPTION
Reducing damage and mana cost of Orb by 20% to address balance in power of orb over other magic based items. Mana return is based off original mana cost so no other mana changes should be needed.

base damage from 22 > 18

base mana cost from 25 > 20