### PR TITLE
Misc fixes (Bolt4Tome/MaskOfTheFather/MagicWeaponImbue)

### DIFF
--- a/Items/tsorcGlobalItem.cs
+++ b/Items/tsorcGlobalItem.cs
@@ -22,6 +22,11 @@ namespace tsorcRevamp.Items
 {
     public class tsorcGlobalItem : GlobalItem
     {
+        // Magic Weapon imbue bonuses
+        public static float BonusDamage1 = 30f; // MagicWeapon
+        public static float BonusDamage2 = 50f; // GreatMagicWeapon
+        public static float BonusDamage3 = 75f; // CrystalMagicWeapon
+
         public static List<int> potionList;
         public static List<int> ammoList;
         public static List<int> torchList;
@@ -510,46 +515,6 @@ namespace tsorcRevamp.Items
                 StaminaPlayer.staminaResourceCurrent -= tsorcRevampPlayer.ReduceStamina(scaledUseAnimation);
             }
         }
-        public static float BonusDamage1 = 30f;
-        public static float BonusDamage2 = 50f;
-        public static float BonusDamage3 = 75f;
-        public override void ModifyWeaponDamage(Item item, Player player, ref StatModifier damage)
-        {
-            tsorcRevampPlayer modPlayer = player.GetModPlayer<tsorcRevampPlayer>();
-            if (item.CountsAsClass(DamageClass.Melee))
-            {
-                /*Main.NewText("magicDamage: " + player.GetDamage(DamageClass.Magic));
-				Main.NewText("magicDamageMult: " + player.GetDamage(DamageClass.Magic)Mult);
-				Main.NewText((player.GetDamage(DamageClass.Magic) - player.GetDamage(DamageClass.Magic)Mult) * .5f);*/
-
-                if (modPlayer.MagicWeapon)
-                {
-                    float bonusDamage = ((player.GetDamage(DamageClass.Magic).Additive * player.GetDamage(DamageClass.Magic).Multiplicative) - 1) * BonusDamage1 / 100f;
-                    if (bonusDamage >= 0)
-                    {
-                        player.GetDamage(DamageClass.Melee) += bonusDamage;
-                    }
-                }
-                if (modPlayer.GreatMagicWeapon)
-                {
-                    float bonusDamage = ((player.GetDamage(DamageClass.Magic).Additive * player.GetDamage(DamageClass.Magic).Multiplicative) - 1) * BonusDamage2 / 100f;
-                    if (bonusDamage >= 0)
-                    {
-                        player.GetDamage(DamageClass.Melee) += bonusDamage;
-                    }
-                }
-                if (modPlayer.CrystalMagicWeapon)
-                {
-                    float bonusDamage = (player.GetDamage(DamageClass.Magic).Additive * player.GetDamage(DamageClass.Magic).Multiplicative) * BonusDamage3 / 100f;
-                    if (bonusDamage >= 0)
-                    {
-                        player.GetDamage(DamageClass.Melee) += bonusDamage;
-                    }
-                }
-            }
-        }
-
-        
 
         public override bool OnPickup(Item item, Player player)
         {

--- a/Player/tsorcRevampPlayerMain.cs
+++ b/Player/tsorcRevampPlayerMain.cs
@@ -861,6 +861,10 @@ namespace tsorcRevamp
             {
                 target.AddBuff(BuffID.Daybreak, 180);
             }
+            if (MaskOfTheFather)
+            {
+                modifiers.CritDamage += Items.Armors.MaskOfTheFather.CritDmgIncrease / 100f;
+            }
         }
         public override void ModifyHitNPCWithItem(Item item, NPC target, ref NPC.HitModifiers modifiers)/* tModPorter If you don't need the Item, consider using ModifyHitNPC instead */
         {
@@ -917,10 +921,6 @@ namespace tsorcRevamp
             if (modifiers.DamageType == DamageClass.Ranged && InfinityEdge)
             {
                 modifiers.CritDamage += Items.Accessories.Ranged.InfinityEdge.CritDmgIncrease / 100f;
-            }
-            if (MaskOfTheFather)
-            {
-                modifiers.CritDamage += Items.Armors.MaskOfTheFather.CritDmgIncrease / 100f;
             }
             if (((proj.type == ProjectileID.MoonlordArrow) || (proj.type == ProjectileID.MoonlordArrowTrail)) && Player.HeldItem.type == ModContent.ItemType<Items.Weapons.Ranged.Bows.CernosPrime>())
             {

--- a/Player/tsorcRevampPlayerUpdateLoops.cs
+++ b/Player/tsorcRevampPlayerUpdateLoops.cs
@@ -1801,6 +1801,37 @@ namespace tsorcRevamp
                 }
             }
 
+            if (Player.HeldItem.CountsAsClass(DamageClass.Melee))
+            {
+                /*Main.NewText("magicDamage: " + player.GetDamage(DamageClass.Magic));
+				Main.NewText("magicDamageMult: " + player.GetDamage(DamageClass.Magic)Mult);
+				Main.NewText((player.GetDamage(DamageClass.Magic) - player.GetDamage(DamageClass.Magic)Mult) * .5f);*/
+                if (Player.HasBuff(ModContent.BuffType<MagicWeapon>()))
+                {
+                    float bonusDamage = ((Player.GetDamage(DamageClass.Magic).Additive * Player.GetDamage(DamageClass.Magic).Multiplicative) - 1) * Items.tsorcGlobalItem.BonusDamage1 / 100f;
+                    if (bonusDamage >= 0)
+                    {
+                        Player.GetDamage(DamageClass.Melee) += bonusDamage;
+                    }
+                }
+                if (Player.HasBuff(ModContent.BuffType<GreatMagicWeapon>()))
+                {
+                    float bonusDamage = ((Player.GetDamage(DamageClass.Magic).Additive * Player.GetDamage(DamageClass.Magic).Multiplicative) - 1) * Items.tsorcGlobalItem.BonusDamage2 / 100f;
+                    if (bonusDamage >= 0)
+                    {
+                        Player.GetDamage(DamageClass.Melee) += bonusDamage;
+                    }
+                }
+                if (Player.HasBuff(ModContent.BuffType<CrystalMagicWeapon>()))
+                {
+                    float bonusDamage = (Player.GetDamage(DamageClass.Magic).Additive * Player.GetDamage(DamageClass.Magic).Multiplicative) * Items.tsorcGlobalItem.BonusDamage3 / 100f;
+                    if (bonusDamage >= 0)
+                    {
+                        Player.GetDamage(DamageClass.Melee) += bonusDamage;
+                    }
+                }
+            }
+
             if (WaterWalkingBoots)
             {
                 if (LavaWalkCount < LavaWalkTimer)

--- a/Projectiles/Magic/Bolt4Lightning.cs
+++ b/Projectiles/Magic/Bolt4Lightning.cs
@@ -337,6 +337,10 @@ namespace tsorcRevamp.Projectiles.Magic
         public static Effect blurEffect;
         public void CreateRenderTarget()
         {
+            if (branches == null)
+            {
+                return;
+            }
             //Potential better version of this: Rotate them just like is done when drawing them, and calcualte their max X and Y offset of every single branch node
             //Probably an unnecessary optimization, but an option for if it does become necessary in the future
             lightningMaxDimensions.X = 0;


### PR DESCRIPTION
https://discord.com/channels/562460572881256450/1409549184905773106/1425717688793043005
speculative fix for Bolt4Tome crashing in multiplayer 
<img width="1897" height="665" alt="image" src="https://github.com/user-attachments/assets/0b75255f-2b93-49f3-be94-bcb9e3b32b9a" />

i wasn't able to recreate the error, but guessing some network lag based race condition might be happening causing a multiplayer client to call `CreateRenderTarget()` before `AI()`. if `CreateRenderTarget()` returns early, logging shows it will retry the call, so hopefully at some point between calls `AI()` will get called to instantiate `branches`

---

https://discord.com/channels/562460572881256450/1416967809996685453/1416967809996685453

move MaskOfTheFather crit modification from ModifyHitNPCWithProj to ModifyHitNPC

Mask of the Father description has `Critical strikes deal 15% more damage`, which sounds like it should apply to all damage

--- 

https://discord.com/channels/562460572881256450/1416967809996685453/1416967809996685453 (same as previous)

move Magic Weapon imbue damage buff from GlobalItem.ModifyWeaponDamage to PostUpdateEquips to fix swing damage

magic weapon that imbue have descriptions like `Convert X% of magic damage bonus to melee damage bonus`, but were only buffing special abilities of melee weapons (like magmatooth's volcano every 8th swing) and not normal melee swing damage