### PR TITLE
have Gaebolg poke/thrown subclass ModdedSpearPojectile*

### DIFF
--- a/Projectiles/Melee/ModdedSpearProjectileThrown.cs
+++ b/Projectiles/Melee/ModdedSpearProjectileThrown.cs
@@ -11,22 +11,48 @@ namespace tsorcRevamp.Projectiles.Melee
     // Parent class for thrown spears where hitbox is centered on spear tip
     public abstract class ModdedSpearProjectileThrown : ModProjectile
     {
+        // Size of the hitbox at the tip of the spear
+        public abstract int HitboxSize { get; }
+        // Armor shader applied when `Projectile.ai[0] == 1`
+        public abstract int ChargedShaderID { get; }
+
+        // See Projectile.extraUpdates
+        public virtual int ExtraUpdates { get => 0; }
+        // See Projectile.light
+        public virtual float Light { get => 0f; }
+        // See Projectile.penetrate
+        public virtual int Penetrate { get => 1; }
+        // See Projectile.scale
+        public virtual float Scale { get => 1f; }
+        // See Projectile.timeLeft
+        public virtual int TimeLeft { get => 3600; }
+
+        // Dust drawing logic to use in AI(), if any
+        public virtual void AIDust() { }
+        // Dust drawing logic to use in PreKill(), if any
+        public virtual void PreKillDust() { }
+
         public override void SetDefaults()
         {
             Projectile.aiStyle = -1;
             Projectile.hostile = false;
             Projectile.friendly = true;
-            Projectile.height = 30;
-            Projectile.light = 0.7f;
+            Projectile.height = HitboxSize;
+            Projectile.light = Light;
             Projectile.DamageType = DamageClass.Melee;
-            Projectile.scale = 1.2f;
-            Projectile.width = 30;
+            Projectile.scale = Scale;
+            Projectile.width = HitboxSize;
             Projectile.tileCollide = false;
             Projectile.timeLeft = 300;
-            Projectile.extraUpdates = 1;
+            Projectile.extraUpdates = ExtraUpdates;
+            Projectile.penetrate = Penetrate;
         }
 
-        public static Texture2D texture;
+        // Texture was being static cached in child classes but leaked when the logic was moved to
+        // a parent class. Making it an instance variable for now, but if this ends up being an
+        // efficiency issue then can probably set a static texture map / dictionary here, or have
+        // children provide their static texture.
+        public Texture2D texture;
         public override void OnSpawn(IEntitySource source)
         {
             // Since projectile is centered on spear tip for collision hitbox, offset starting
@@ -48,7 +74,7 @@ namespace tsorcRevamp.Projectiles.Melee
 
             if (Projectile.ai[0] == 1)
             {
-                ArmorShaderData data = GameShaders.Armor.GetSecondaryShader((byte)GameShaders.Armor.GetShaderIdFromItemId(ItemID.RedDye), Main.LocalPlayer);
+                ArmorShaderData data = GameShaders.Armor.GetSecondaryShader((byte)GameShaders.Armor.GetShaderIdFromItemId(ChargedShaderID), Main.LocalPlayer);
                 data.Apply(null);
             }
 
@@ -83,37 +109,7 @@ namespace tsorcRevamp.Projectiles.Melee
             //projectile.velocity.Y += (9.8f / 60); //This is its gravity. Comes out to about 0.16 per frame, which is actually really high!!
             Projectile.velocity.Y += 0.1f;
 
-            if (Main.rand.NextBool(3))
-            {
-                int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 90, Projectile.velocity.X * -0.2f, Projectile.velocity.Y * -0.2f, 70, default(Color), 1.3f);
-                Main.dust[dust].noGravity = true;
-            }
-        }
-
-        public override void PostDraw(Color lightColor)
-        {
-            Texture2D texture = (Texture2D)Terraria.GameContent.TextureAssets.Projectile[Projectile.type];
-            Vector2 origin = new Vector2(texture.Width / 2f, texture.Height / 2f);
-            Vector2 spearTipOffset = origin.RotatedBy(Projectile.rotation);
-            Vector2 drawPosition = Projectile.Center - Main.screenPosition + spearTipOffset;
-
-            for (int i = 1; i <= 5; i++)
-            {
-                Vector2 offset = Projectile.velocity * -i * 1.2f;
-                float alpha = 0.4f * (1f - (i / 6f));
-
-                Main.EntitySpriteDraw(
-                    texture,
-                    drawPosition + offset,
-                    null,
-                    lightColor * alpha,
-                    Projectile.rotation,
-                    origin,
-                    Projectile.scale,
-                    SpriteEffects.None
-                    
-                );
-            }
+            AIDust();
         }
 
         public override bool PreKill(int timeleft)
@@ -121,10 +117,7 @@ namespace tsorcRevamp.Projectiles.Melee
             Projectile.type = ProjectileID.WoodenArrowHostile;
 
             Terraria.Audio.SoundEngine.PlaySound(SoundID.Dig, Projectile.Center);
-            for (int i = 0; i < 12; i++)
-            {
-                Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 219, 0, 0, 0, default, 1.4f);
-            }
+            PreKillDust();
             return true;
         }
     }

--- a/Projectiles/Melee/Spears/GaeBolgPoke.cs
+++ b/Projectiles/Melee/Spears/GaeBolgPoke.cs
@@ -1,126 +1,36 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
 
-//using tsorcRevamp.Dusts;
-
 namespace tsorcRevamp.Projectiles.Melee.Spears
 {
-    class GaeBolgPoke : ModProjectile
+    class GaeBolgPoke : ModdedSpearProjectile
     {
+        public override float HoldoutRangeMin => 75f;
+        public override float HoldoutRangeMax => 160f;
+        public override float HitboxSize => 1;
+        public override float Scale => 1.1f;
+        public override int dustID => -2; // skip ModdedSpearProjectile default dust
 
         public override void SetDefaults()
         {
+            base.SetDefaults();
             Projectile.width = 30;
             Projectile.height = 30;
-            Projectile.penetrate = -1;
-            Projectile.timeLeft = 3600;
-            Projectile.friendly = true; //can hit enemies
-            Projectile.hostile = false; //can hit player / friendly NPCs
             Projectile.ownerHitCheck = false;
-            Projectile.DamageType = DamageClass.Melee;
-            Projectile.tileCollide = false;
-            Projectile.hide = true;
             Projectile.usesLocalNPCImmunity = true;
             Projectile.localNPCHitCooldown = 10;
-            Projectile.scale = 1.1f;
-
-        }
-        public float moveFactor
-        { //controls spear speed
-            get => Projectile.ai[0];
-            set => Projectile.ai[0] = value;
         }
 
-        public override void AI()
+        public override void CustomDust()
         {
-            //DrawOffsetX = -35;
-            Player pOwner = Main.player[Projectile.owner];
-            Projectile.Center = pOwner.RotatedRelativePoint(pOwner.MountedCenter, true);
-            Projectile.direction = pOwner.direction;
-            pOwner.heldProj = Projectile.whoAmI;
-            pOwner.itemTime = pOwner.itemAnimation;
-
-            if (!pOwner.frozen)
-            {
-                if (moveFactor == 0f)
-                { //when initially thrown
-                    moveFactor = 4.1f; //move forward
-                    Projectile.netUpdate = true;
-                }
-                if (pOwner.itemAnimation < pOwner.itemAnimationMax / 2)
-                { //after x animation frames, return
-                    moveFactor -= 2.85f;
-                }
-                else
-                { //extend spear
-                    moveFactor += 4.1f;
-                }
-
-            }
-
-            if (pOwner.itemAnimation == 0)
-            {
-                Projectile.Kill();
-            }
-
-            Projectile.Center += Projectile.velocity * moveFactor;
-
-            Projectile.rotation = Projectile.velocity.ToRotation() + MathHelper.PiOver2 + MathHelper.ToRadians(45f);
-
             if (Main.rand.NextBool(2))
             {
-                Vector2 spearTipOffset = new Vector2(60 * MathF.Cos(Projectile.velocity.ToRotation()), 100 * MathF.Sin(Projectile.velocity.ToRotation()));
-                int dust = Dust.NewDust(Projectile.position + spearTipOffset, Projectile.width, Projectile.height, 15, Projectile.velocity.X * -0.2f, Projectile.velocity.Y * -0.2f, 70, default(Color), 1.2f);
+                int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 15, Projectile.velocity.X * -0.2f, Projectile.velocity.Y * -0.2f, 70, default(Color), 1.2f);
                 Main.dust[dust].noGravity = true;
             }
         }
-
-        public override void ModifyDamageHitbox(ref Rectangle hitbox)
-        {
-            // Move damage hitbox to where spear tip is
-            double spearTipOffsetX = 60 * Math.Cos(Projectile.velocity.ToRotation());
-            double spearTipOffsetY = 60 * Math.Sin(Projectile.velocity.ToRotation());
-            hitbox.Offset((int)spearTipOffsetX, (int)spearTipOffsetY);
-        }
-
-		public override void CutTiles()
-		{
-			// Move vine/pot breaking to where spear tip is
-            Vector2 spearTipOffsetStarting = new Vector2(85 * MathF.Cos(Projectile.velocity.ToRotation()), 85 * MathF.Sin(Projectile.velocity.ToRotation()));
-            Vector2 spearTipOffsetEnding = new Vector2(115 * MathF.Cos(Projectile.velocity.ToRotation()), 115 * MathF.Sin(Projectile.velocity.ToRotation()));
-			Utils.PlotTileLine(Projectile.Center + spearTipOffsetStarting, Projectile.Center + spearTipOffsetEnding, 70, DelegateMethods.CutTiles);
-		}
-
-        public static Texture2D texture;
-        public override bool PreDraw(ref Color lightColor)
-        {
-            SpriteEffects spriteEffects = SpriteEffects.None;
-            if (Projectile.spriteDirection == -1)
-            {
-                spriteEffects = SpriteEffects.FlipHorizontally;
-            }
-
-            if (texture == null || texture.IsDisposed)
-            {
-                texture = (Texture2D)ModContent.Request<Texture2D>(Projectile.ModProjectile.Texture);
-            }
-
-            Rectangle sourceRectangle = new Rectangle(0, 0, texture.Width, texture.Height);
-            Vector2 origin = sourceRectangle.Size() / 2f;
-
-            Vector2 offset = Projectile.velocity * 25;
-
-            Main.EntitySpriteDraw(texture,
-                Projectile.Center - Main.screenPosition + new Vector2(DrawOffsetX, Projectile.gfxOffY) - offset,
-                sourceRectangle, lightColor, Projectile.rotation, origin, Projectile.scale, spriteEffects, 0);
-
-            return false;
-        }
-
     }
-
 }

--- a/Projectiles/Melee/Spears/GaeBolgThrown.cs
+++ b/Projectiles/Melee/Spears/GaeBolgThrown.cs
@@ -1,79 +1,20 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria;
-using Terraria.Graphics.Shaders;
 using Terraria.ID;
-using Terraria.ModLoader;
 
 
 namespace tsorcRevamp.Projectiles.Melee.Spears
 {
-    class GaeBolgThrown : ModProjectile
+    class GaeBolgThrown : ModdedSpearProjectileThrown
     {
+        public override int HitboxSize => 24;
+        public override int ChargedShaderID => ItemID.StardustDye;
 
-        public override void SetDefaults()
-        {
-            Projectile.aiStyle = -1;
-            Projectile.hostile = false;
-            Projectile.friendly = true;
-            Projectile.height = 24;
-            Projectile.light = 0.6f;
-            Projectile.DamageType = DamageClass.Melee;
-            Projectile.scale = 1.1f;
-            Projectile.penetrate = 4;
-            Projectile.width = 24;
-            Projectile.tileCollide = false;
-            Projectile.timeLeft = 240;
-        }
-
-        public static Texture2D texture;
-        public override bool PreDraw(ref Color lightColor)
-        {
-            Main.spriteBatch.End();
-            Main.spriteBatch.Begin(SpriteSortMode.Immediate, BlendState.AlphaBlend, SamplerState.LinearClamp, DepthStencilState.None, RasterizerState.CullNone, null, Main.GameViewMatrix.TransformationMatrix);
-
-            if (Projectile.ai[0] == 1)
-            {
-                ArmorShaderData data = GameShaders.Armor.GetSecondaryShader((byte)GameShaders.Armor.GetShaderIdFromItemId(ItemID.StardustDye), Main.LocalPlayer);
-                data.Apply(null);
-            }
-
-            SpriteEffects spriteEffects = SpriteEffects.None;
-            if (Projectile.spriteDirection == -1)
-            {
-                spriteEffects = SpriteEffects.FlipHorizontally;
-            }
-
-            if (texture == null || texture.IsDisposed)
-            {
-                texture = (Texture2D)ModContent.Request<Texture2D>(Projectile.ModProjectile.Texture);
-            }
-
-            int frameHeight = texture.Height / Main.projFrames[Projectile.type];
-            int startY = frameHeight * Projectile.frame;
-            Rectangle sourceRectangle = new Rectangle(0, startY, texture.Width, frameHeight);
-            Vector2 origin = sourceRectangle.Size() / 2f;
-            Main.EntitySpriteDraw(texture,
-                Projectile.Center - Main.screenPosition + new Vector2(0f, Projectile.gfxOffY),
-                sourceRectangle, Color.White, Projectile.rotation, origin, Projectile.scale, spriteEffects, 0);
-
-            UsefulFunctions.RestartSpritebatch(ref Main.spriteBatch);
-
-            return false;
-        }
-
-        public override void AI()
-        {
-            Projectile.rotation = Projectile.velocity.ToRotation() + MathHelper.PiOver2 + MathHelper.ToRadians(45f); //This makes it rotate to face where it's moving
-            //projectile.velocity.Y += (9.8f / 60); //This is its gravity. Comes out to about 0.16 per frame, which is actually really high!!
-            Projectile.velocity.Y += 0.1f;
-
-            if (Main.rand.NextBool(4))
-            {
-                int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 15, Projectile.velocity.X * -0.2f, Projectile.velocity.Y * -0.2f, 70, default(Color), 1.2f);
-                Main.dust[dust].noGravity = true;
-            }
-        }
+        public override float Light => 0.6f;
+        public override int Penetrate => 4;
+        public override float Scale => 1.1f;
+        public override int TimeLeft => 240;
 
         public override void OnHitNPC(NPC target, NPC.HitInfo hit, int damageDone)
         {
@@ -83,11 +24,29 @@ namespace tsorcRevamp.Projectiles.Melee.Spears
             }
         }
 
+        public override void AIDust()
+        {
+            if (Main.rand.NextBool(4))
+            {
+                int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 15, Projectile.velocity.X * -0.2f, Projectile.velocity.Y * -0.2f, 70, default(Color), 1.2f);
+                Main.dust[dust].noGravity = true;
+            }
+        }
+
+        public override void PreKillDust()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 15, 0, 0, 0, default, 1f);
+            }
+        }
+
         public override void PostDraw(Color lightColor)
         {
             Texture2D texture = (Texture2D)Terraria.GameContent.TextureAssets.Projectile[Projectile.type];
             Vector2 origin = new Vector2(texture.Width / 2f, texture.Height / 2f); 
-            Vector2 drawPosition = Projectile.Center - Main.screenPosition;
+            Vector2 spearTipOffset = origin.RotatedBy(Projectile.rotation);
+            Vector2 drawPosition = Projectile.Center - Main.screenPosition + spearTipOffset;
 
             for (int i = 1; i <= 4; i++)  
             {
@@ -106,18 +65,6 @@ namespace tsorcRevamp.Projectiles.Melee.Spears
                     0
                 );
             }
-        }
-
-        public override bool PreKill(int timeleft)
-        {
-            Projectile.type = ProjectileID.WoodenArrowHostile;
-
-            Terraria.Audio.SoundEngine.PlaySound(SoundID.Dig, Projectile.Center);
-            for (int i = 0; i < 10; i++)
-            {
-                Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 15, 0, 0, 0, default, 1f);
-            }
-            return true;
         }
     }
 }

--- a/Projectiles/Melee/Spears/LonginusThrown.cs
+++ b/Projectiles/Melee/Spears/LonginusThrown.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Terraria;
 using Terraria.ID;
 
@@ -6,6 +7,14 @@ namespace tsorcRevamp.Projectiles.Melee.Spears
 {
     class LonginusThrown : ModdedSpearProjectileThrown
     {
+        public override int HitboxSize => 30;
+        public override int ChargedShaderID => ItemID.RedDye;
+
+        public override int ExtraUpdates => 1;
+        public override float Light => 0.7f;
+        public override float Scale => 1.2f;
+        public override int TimeLeft => 300;
+
         public override void OnKill(int timeLeft)
         {
             if (Projectile.ai[0] == 1)
@@ -15,11 +24,11 @@ namespace tsorcRevamp.Projectiles.Melee.Spears
                     Vector2 direction = Main.rand.NextVector2Circular(1f, 1f).SafeNormalize(Vector2.UnitX);
                     float speed = Main.rand.NextFloat(5.5f, 19f);
 
-                    int dust1 = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 90, 0f, 0f, 70, default, 1.55f);
+                    int dust1 = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.GemRuby, 0f, 0f, 70, default, 1.55f);
                     Main.dust[dust1].velocity = direction * speed;
                     Main.dust[dust1].noGravity = true;
 
-                    int dust2 = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, 219, 0f, 0f, 70, default, 1.95f);
+                    int dust2 = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.Fireworks, 0f, 0f, 70, default, 1.95f);
                     Main.dust[dust2].velocity = direction * (speed * 1.2f);
                     Main.dust[dust2].noGravity = true;
                 }
@@ -32,6 +41,49 @@ namespace tsorcRevamp.Projectiles.Melee.Spears
                 Projectile.position = oldCenter - new Vector2(Projectile.width / 2f, Projectile.height / 2f);
                 Projectile.damage /= 2;
                 Projectile.Damage();
+            }
+        }
+
+        public override void AIDust()
+        {
+            if (Main.rand.NextBool(3))
+            {
+                int dust = Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.GemRuby, Projectile.velocity.X * -0.2f, Projectile.velocity.Y * -0.2f, 70, default(Color), 1.3f);
+                Main.dust[dust].noGravity = true;
+            }
+        }
+
+        public override void PreKillDust()
+        {
+            for (int i = 0; i < 12; i++)
+            {
+                Dust.NewDust(Projectile.position, Projectile.width, Projectile.height, DustID.Fireworks, 0, 0, 0, default, 1.4f);
+            }
+        }
+
+        public override void PostDraw(Color lightColor)
+        {
+            Texture2D texture = (Texture2D)Terraria.GameContent.TextureAssets.Projectile[Projectile.type];
+            Vector2 origin = new Vector2(texture.Width / 2f, texture.Height / 2f);
+            Vector2 spearTipOffset = origin.RotatedBy(Projectile.rotation);
+            Vector2 drawPosition = Projectile.Center - Main.screenPosition + spearTipOffset;
+
+            for (int i = 1; i <= 5; i++)
+            {
+                Vector2 offset = Projectile.velocity * -i * 1.2f;
+                float alpha = 0.4f * (1f - (i / 6f));
+
+                Main.EntitySpriteDraw(
+                    texture,
+                    drawPosition + offset,
+                    null,
+                    lightColor * alpha,
+                    Projectile.rotation,
+                    origin,
+                    Projectile.scale,
+                    SpriteEffects.None,
+                    0
+                );
             }
         }
     }


### PR DESCRIPTION
trying to have texture vs projectile center / hitbox logic 'just work' for subclasses, though left PostDraw alone for now since i couldnt think up a satisfying way to deal with alpha / offset, and iteration bounds.

options for future?
- children implement `PostDrawAfterimage(lightColor, texture, origin, drawPosition)` and call Main.EntitySpriteDraw
- children provide PostDrawAfterimageCount(), PostDrawAfterimageOffset(i), and PostDrawAfterimageAlpha(i)