### PR TITLE
 Sync tsorcRevampWorld.DwarvenContractsGiven in multiplayer

### DIFF
--- a/NPCs/Friendly/Dwarf.cs
+++ b/NPCs/Friendly/Dwarf.cs
@@ -141,7 +141,18 @@ namespace tsorcRevamp.NPCs.Friendly
             // Consume the Contract
             player.ConsumeItem(ModContent.ItemType<DwarvenContract>());
             givenContract++;
-            tsorcRevampWorld.DwarvenContractsGiven = givenContract;
+
+            if (Main.netMode == NetmodeID.SinglePlayer)
+            {
+                tsorcRevampWorld.DwarvenContractsGiven = givenContract;
+            }
+            else
+            {
+                ModPacket dwarvenContractPacket = ModContent.GetInstance<tsorcRevamp>().GetPacket();
+                dwarvenContractPacket.Write(tsorcPacketID.SyncDwarvenContract);
+                dwarvenContractPacket.Write(givenContract);
+                dwarvenContractPacket.Send();
+            }
 
             // Rewards
             switch (givenContract)

--- a/tsorcRevamp.cs
+++ b/tsorcRevamp.cs
@@ -2190,6 +2190,17 @@ namespace tsorcRevamp
                         break;
                     }
 
+                case tsorcPacketID.SyncDwarvenContract:
+                    {
+                        int dwarvenContractsGiven = reader.ReadInt32();
+                        if (Main.netMode == NetmodeID.Server)
+                        {
+                            tsorcRevampWorld.DwarvenContractsGiven = dwarvenContractsGiven;
+                            NetMessage.SendData(MessageID.WorldData);
+                        }
+                        break;
+                    }
+
                 default:
                     {
                         Logger.InfoFormat("[tsorcRevamp] Sync failed. Unknown message ID: {0}", message);
@@ -3720,6 +3731,11 @@ namespace tsorcRevamp
         /// so the packet handler can find the renderer.
         /// </summary>
         public const byte SyncEnemyActivePose = 21;
+
+        /// <summary>
+        /// Syncs tsorcRevampWorld.DwarvenContractsGiven across players
+        /// </summary>
+        public const byte SyncDwarvenContract = 22;
     }
 
     //config moved to separate file


### PR DESCRIPTION
tsorcRevampWorld.DwarvenContractsGiven is synced on world join (and probably during other MessageID.WorldData syncs), but could get out of sync otherwise like so:
- player A gives contract, gets reward for `givenContract=1`
- player B joins, receives world data with `tsorcRevampWorld.DwarvenContractsGiven = 1`
- player A gives contract, gets reward for `givenContract=2`
- player B gives contract, gets reward for `givenContract=2`

this change makes it so multiplayer clients (players A and B) send givenContract count to server, and then server triggers world sync after updating tsorcRevampWorld.DwarvenContractsGiven